### PR TITLE
Add copyright headers

### DIFF
--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -1,5 +1,4 @@
-/*
- * Copyright 2023 The Backstage Authors
+/* Copyright 2023 Axis Communications AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/jira-dashboard-common/src/index.ts
+++ b/plugins/jira-dashboard-common/src/index.ts
@@ -1,5 +1,4 @@
-/*
- * Copyright 2023 The Backstage Authors
+/* Copyright 2023 Axis Communications AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/jira-dashboard-common/src/setupTests.ts
+++ b/plugins/jira-dashboard-common/src/setupTests.ts
@@ -1,5 +1,4 @@
-/*
- * Copyright 2023 The Backstage Authors
+/* Copyright 2023 Axis Communications AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/jira-dashboard-common/src/types.ts
+++ b/plugins/jira-dashboard-common/src/types.ts
@@ -1,5 +1,4 @@
-/*
- * Copyright 2023 The Backstage Authors
+/* Copyright 2023 Axis Communications AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {
   Content,
   ContentHeader,

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/index.ts
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/index.ts
@@ -1,1 +1,15 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export { JiraDashboardContent } from './JiraDashboardContent';

--- a/plugins/jira-dashboard/src/components/JiraProjectCard/JiraProjectCard.tsx
+++ b/plugins/jira-dashboard/src/components/JiraProjectCard/JiraProjectCard.tsx
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React from 'react';
 import { Card, Box, Divider, Typography } from '@material-ui/core';
 import { Avatar } from '@backstage/core-components';

--- a/plugins/jira-dashboard/src/components/JiraProjectCard/ProjectInfoLabel.tsx
+++ b/plugins/jira-dashboard/src/components/JiraProjectCard/ProjectInfoLabel.tsx
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React from 'react';
 import { Box, Typography } from '@material-ui/core';
 

--- a/plugins/jira-dashboard/src/components/JiraProjectCard/index.ts
+++ b/plugins/jira-dashboard/src/components/JiraProjectCard/index.ts
@@ -1,1 +1,15 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export { JiraProjectCard } from './JiraProjectCard';

--- a/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React from 'react';
 import { Typography, makeStyles } from '@material-ui/core';
 import { JiraDataResponse } from '@internal/plugin-jira-dashboard-common';

--- a/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import React from 'react';
 import { Link, TableColumn } from '@backstage/core-components';
 import { Issue } from '@internal/plugin-jira-dashboard-common';

--- a/plugins/jira-dashboard/src/components/JiraTable/index.ts
+++ b/plugins/jira-dashboard/src/components/JiraTable/index.ts
@@ -1,1 +1,15 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export { JiraTable } from './JiraTable';

--- a/plugins/jira-dashboard/src/hooks/useJira.ts
+++ b/plugins/jira-dashboard/src/hooks/useJira.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import useAsync from 'react-use/lib/useAsync';
 import { JiraResponse } from '@internal/plugin-jira-dashboard-common';
 import { JiraDashboardApi } from '../api';

--- a/plugins/jira-dashboard/src/index.ts
+++ b/plugins/jira-dashboard/src/index.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export {
   jiraDashboardPlugin,
   EntityJiraDashboardContent,

--- a/plugins/jira-dashboard/src/lib.ts
+++ b/plugins/jira-dashboard/src/lib.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { Project } from '@internal/plugin-jira-dashboard-common';
 
 /**

--- a/plugins/jira-dashboard/src/plugin.test.ts
+++ b/plugins/jira-dashboard/src/plugin.test.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { jiraDashboardPlugin } from './plugin';
 
 describe('jira-dashboard', () => {

--- a/plugins/jira-dashboard/src/plugin.ts
+++ b/plugins/jira-dashboard/src/plugin.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {
   createPlugin,
   createRoutableExtension,

--- a/plugins/jira-dashboard/src/routes.ts
+++ b/plugins/jira-dashboard/src/routes.ts
@@ -1,3 +1,17 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({

--- a/plugins/jira-dashboard/src/setupTests.ts
+++ b/plugins/jira-dashboard/src/setupTests.ts
@@ -1,1 +1,15 @@
+/* Copyright 2023 Axis Communications AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import '@testing-library/jest-dom';


### PR DESCRIPTION
Change-Id: I1b601da9b250a7a711c4bddd7e6650d6fe38df30

### Describe your changes

Added copyright headers to frontend and common plugin files. The following copy right header was used:

```
/* Copyright 2023 Axis Communications AB
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
