### PR TITLE
Remove building image from basic workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Build all
         run: yarn build:all
 
-      - name: Build image
-        run: yarn workspace backend build-image
-
   test:
     name: Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Change-Id: I163b829acf56cdfb34a325efa0779641782c6078

### Describe your changes

Since building image was not relevant for our project, the building image command in the ci.yml file has been removed.

