### PR TITLE
Fix broken links in README

### DIFF
--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Jira Dashboard plugin!
 
-![home](media/project-card.png)
+![project-card](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard/media/project-card.png)
 
 ## Introduction
 
@@ -75,4 +75,4 @@ metadata:
 
 The issue overview is located under the tab "Jira Dashboard" on the entity page. The overview displays information about the specific Jira project, and then renders one table for each type of issue view. In each view you can see the priority, assignee and status for that issue.
 
-![home](media/overview.png)
+![overview](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard/media/overview.png)

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the readme plugin!
 
-![home](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-card.png)
+![readme-card](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-card.png)
 
 ## Introduction
 
@@ -52,9 +52,9 @@ const overviewContent = (
 
 The readme card is located in the overview page on the entity page. From the card header it is also possible to open a dialog displaying the full README.md.
 
-![home](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-card.png)
+![readme-card](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-card.png)
 
-![home](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-dialog.png)
+![readme-dialog](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/media/readme-dialog.png)
 
 ### Troubleshooting
 


### PR DESCRIPTION
### Describe your changes

The Jira Dashboard plugin did have some broken links in the npm package page. This has been fixed + updated the alt text in two README:s.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code