### PR TITLE
Remove single quotes from README

### DIFF
--- a/.changeset/violet-insects-hope.md
+++ b/.changeset/violet-insects-hope.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Removed the single quotes from documentation config strings

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -24,8 +24,8 @@ The Jira Dashboard plugin requires the following YAML to be added to your app-co
 ```yaml
 jiraDashboard:
   token: ${JIRA_TOKEN}
-  baseUrl: ${JIRA_BASE_URL}'
-  userEmailSuffix: ${JIRA_EMAIL_SUFFIX}'
+  baseUrl: ${JIRA_BASE_URL}
+  userEmailSuffix: ${JIRA_EMAIL_SUFFIX}
 ```
 
 Configuration Details:


### PR DESCRIPTION
### Describe your changes

In the README.md of the Jira Dashboard backend plugin, two single quotes were accidentally placed in the end of the config strings. These has been removed.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system