### PR TITLE
fix readme typo Grid prop sx -> xs

### DIFF
--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -41,7 +41,7 @@ import { ReadmeCard } from '@axis-backstage/plugin-readme';
 
 const overviewContent = (
 ...
-  <Grid item md={6} sx={12}>
+  <Grid item md={6} xs={12}>
       <ReadmeCard />
   </Grid>
   ...


### PR DESCRIPTION
`Grid` component has `xs` prop, not `sx`. This PR updates readme.md file

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
