### PR TITLE
Provide compatibility with other annotations

### DIFF
--- a/.changeset/swift-turtles-arrive.md
+++ b/.changeset/swift-turtles-arrive.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Created optional ANNOTATION_PREFIX config in backend to make it possible to define custom annotations. The jira.com annotation is still used if no config value is provided. Also removed check for annotation in frontend and only return error message 'Could not fetch Jira Dashboard content for defined project key' if no Jira data is returned from backend.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -212,7 +212,7 @@ const websiteEntityPage = (
     </EntityLayout.Route>
 
     <EntityLayout.Route
-      if={entity => isJiraDashboardAvailable(entity, 'jira')}
+      if={isJiraDashboardAvailable}
       path="/jira-dashboard"
       title="Jira Dashboard"
     >

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -212,7 +212,7 @@ const websiteEntityPage = (
     </EntityLayout.Route>
 
     <EntityLayout.Route
-      if={isJiraDashboardAvailable}
+      if={entity => isJiraDashboardAvailable(entity, 'jira')}
       path="/jira-dashboard"
       title="Jira Dashboard"
     >

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -26,6 +26,7 @@ jiraDashboard:
   token: ${JIRA_TOKEN}
   baseUrl: ${JIRA_BASE_URL}
   userEmailSuffix: ${JIRA_EMAIL_SUFFIX}
+  annotationPrefix?: ${JIRA_ANNOTATION_PREFIX}
 ```
 
 Configuration Details:
@@ -34,6 +35,7 @@ Configuration Details:
   > Note: The JIRA_TOKEN variable from [Roadie's Backstage Jira plugin](https://roadie.io/backstage/plugins/jira) can not be reused here because of the added encoding in this token.
 - `JIRA_BASE_URL`: The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
 - `JIRA_EMAIL_SUFFIX`: The email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com
+- `JIRA_ANNOTATION_PREFIX`: Optional annotation prefix for retrieving a custom annotation to use when retreving Jira information. For instance 'jira'. Defaut value is jira.com
 
 ### Integrating
 

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -35,7 +35,7 @@ Configuration Details:
   > Note: The JIRA_TOKEN variable from [Roadie's Backstage Jira plugin](https://roadie.io/backstage/plugins/jira) can not be reused here because of the added encoding in this token.
 - `JIRA_BASE_URL`: The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
 - `JIRA_EMAIL_SUFFIX`: The email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com
-- `JIRA_ANNOTATION_PREFIX`: Optional annotation prefix for retrieving a custom annotation to use when retreving Jira information. For instance 'jira'. Defaut value is jira.com
+- `JIRA_ANNOTATION_PREFIX`: Optional annotation prefix for retrieving a custom annotation. For instance 'jira'. Defaut value is jira.com
 
 ### Integrating
 

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -19,7 +19,6 @@ export interface Config {
 
     /**
      * Optional annotation prefix for retrieving a custom annotation to use when retreving Jira information. Defaut value is jira.com
-     * @visibility frontend
      */
     annotationPrefix?: string;
   };

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -18,7 +18,7 @@ export interface Config {
     userEmailSuffix: string;
 
     /**
-     * Optional annotation prefix for retrieving a specific Jira annotation from catalog-info.yaml. Defaut value is jira.com
+     * Optional annotation prefix for retrieving a custom annotation to use when retreving Jira information. Defaut value is jira.com
      * @visibility frontend
      */
     annotationPrefix?: string;

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -16,5 +16,11 @@ export interface Config {
      * The email suffix used for retreiving a specific Jira user in a company. For instance @your-company.com
      */
     userEmailSuffix: string;
+
+    /**
+     * Optional annotation prefix for retrieving a specific Jira annotation from catalog-info.yaml. Defaut value is jira.com
+     * @visibility frontend
+     */
+    annotationPrefix?: string;
   };
 }

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -18,7 +18,7 @@ export interface Config {
     userEmailSuffix: string;
 
     /**
-     * Optional annotation prefix for retrieving a custom annotation to use when retreving Jira information. Defaut value is jira.com
+     * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
      */
     annotationPrefix?: string;
   };

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -1,9 +1,9 @@
 import { Config } from '@backstage/config';
 
-const JIRA_ANNOTATION = 'jiraDashboard.annotationPrefix';
 const JIRA_BASE_URL_CONFIG_PATH = 'jiraDashboard.baseUrl';
 const JIRA_TOKEN_CONFIG_PATH = 'jiraDashboard.token';
 const JIRA_USER_CONFIG_EMAIL_SUFFIX = 'jiraDashboard.userEmailSuffix';
+const JIRA_ANNOTATION = 'jiraDashboard.annotationPrefix';
 
 export function resolveJiraBaseUrl(config: Config): string {
   try {

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -31,5 +31,5 @@ export function resolveUserEmailSuffix(config: Config): string {
 
 export function resolveAnnotationPrefix(config: Config): string {
   const annotationPrefix = config.getOptionalString(JIRA_ANNOTATION);
-  return annotationPrefix ?? 'axis.com';
+  return annotationPrefix ?? 'jira.com';
 }

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -1,5 +1,6 @@
 import { Config } from '@backstage/config';
 
+const JIRA_ANNOTATION = 'jiraDashboard.annotationPrefix';
 const JIRA_BASE_URL_CONFIG_PATH = 'jiraDashboard.baseUrl';
 const JIRA_TOKEN_CONFIG_PATH = 'jiraDashboard.token';
 const JIRA_USER_CONFIG_EMAIL_SUFFIX = 'jiraDashboard.userEmailSuffix';
@@ -26,4 +27,9 @@ export function resolveUserEmailSuffix(config: Config): string {
   } catch (error) {
     throw new Error(`Invalid Jira user path, ${error}`);
   }
+}
+
+export function resolveAnnotationPrefix(config: Config): string {
+  const annotationPrefix = config.getOptionalString(JIRA_ANNOTATION);
+  return annotationPrefix ?? 'axis.com';
 }

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -1,0 +1,21 @@
+import { resolveAnnotationPrefix } from './config';
+import {
+  COMPONENTS_NAME,
+  PROJECT_KEY_NAME,
+  FILTERS_NAME,
+} from '@axis-backstage/plugin-jira-dashboard-common';
+import { Config } from '@backstage/config';
+
+export const getAnnotations = (config: Config) => {
+  const prefix = resolveAnnotationPrefix(config);
+
+  const projectKeyAnnotation = `${prefix}/${PROJECT_KEY_NAME}`;
+  const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
+  const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
+
+  return {
+    projectKeyAnnotation,
+    componentsAnnotation,
+    filtersAnnotation,
+  };
+};

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -13,11 +13,11 @@ import { IdentityApi } from '@backstage/plugin-auth-node';
 
 import { getDefaultFilters } from '../filters';
 import {
-  COMPONENT_ANNOTATION,
-  FILTER_ANNOTATION,
+  COMPONENTS_NAME,
+  FILTERS_NAME,
   type Filter,
   type JiraResponse,
-  PROJECT_KEY_ANNOTATION,
+  PROJECT_KEY_NAME,
   type Project,
 } from '@axis-backstage/plugin-jira-dashboard-common';
 import stream from 'stream';
@@ -104,7 +104,7 @@ export async function createRouter(
 
       const projectKey =
         entity.metadata.annotations?.[
-          `${annotationPrefix}/${PROJECT_KEY_ANNOTATION}`
+          `${annotationPrefix}/${PROJECT_KEY_NAME}`
         ]!;
 
       if (!projectKey) {
@@ -136,7 +136,7 @@ export async function createRouter(
 
       const customFilterAnnotations =
         entity.metadata.annotations?.[
-          `${annotationPrefix}/${FILTER_ANNOTATION}`
+          `${annotationPrefix}/${FILTERS_NAME}`
         ]?.split(',')!;
 
       filters = getDefaultFilters(
@@ -154,7 +154,7 @@ export async function createRouter(
 
       const componentAnnotations =
         entity.metadata.annotations?.[
-          `${annotationPrefix}/${COMPONENT_ANNOTATION}`
+          `${annotationPrefix}/${COMPONENTS_NAME}`
         ]?.split(',')!;
 
       if (componentAnnotations) {
@@ -187,9 +187,7 @@ export async function createRouter(
     }
 
     const projectKey =
-      entity.metadata.annotations?.[
-        `${annotationPrefix}/${PROJECT_KEY_ANNOTATION}`
-      ]!;
+      entity.metadata.annotations?.[`${annotationPrefix}/${PROJECT_KEY_NAME}`]!;
 
     const projectResponse = await getProjectResponse(projectKey, config, cache);
 

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -28,6 +28,7 @@ import {
   getIssuesFromFilters,
   getIssuesFromComponents,
 } from './service';
+import { resolveAnnotationPrefix } from '../config';
 
 /**
  * Constructs a jira dashboard router.
@@ -91,6 +92,7 @@ export async function createRouter(
       const entityRef = request.params.entityRef;
       const { token } = await tokenManager.getToken();
       const entity = await catalogClient.getEntityByRef(entityRef, { token });
+      const annotationPrefix = resolveAnnotationPrefix(config);
 
       if (!entity) {
         logger.info(`No entity found for ${entityRef}`);
@@ -100,7 +102,10 @@ export async function createRouter(
         return;
       }
 
-      const projectKey = entity.metadata.annotations?.[PROJECT_KEY_ANNOTATION]!;
+      const projectKey =
+        entity.metadata.annotations?.[
+          `${annotationPrefix}/${PROJECT_KEY_ANNOTATION}`
+        ]!;
 
       if (!projectKey) {
         const error = `No jira.com/project-key annotation found for ${entityRef}`;
@@ -130,7 +135,9 @@ export async function createRouter(
       let filters: Filter[] = [];
 
       const customFilterAnnotations =
-        entity.metadata.annotations?.[FILTER_ANNOTATION]?.split(',')!;
+        entity.metadata.annotations?.[
+          `${annotationPrefix}/${FILTER_ANNOTATION}`
+        ]?.split(',')!;
 
       filters = getDefaultFilters(
         config,
@@ -146,7 +153,9 @@ export async function createRouter(
       let issues = await getIssuesFromFilters(projectKey, filters, config);
 
       const componentAnnotations =
-        entity.metadata.annotations?.[COMPONENT_ANNOTATION]?.split(',')!;
+        entity.metadata.annotations?.[
+          `${annotationPrefix}/${COMPONENT_ANNOTATION}`
+        ]?.split(',')!;
 
       if (componentAnnotations) {
         const componentIssues = await getIssuesFromComponents(
@@ -169,6 +178,7 @@ export async function createRouter(
     const { entityRef } = request.params;
     const { token } = await tokenManager.getToken();
     const entity = await catalogClient.getEntityByRef(entityRef, { token });
+    const annotationPrefix = resolveAnnotationPrefix(config);
 
     if (!entity) {
       logger.info(`No entity found for ${entityRef}`);
@@ -176,7 +186,10 @@ export async function createRouter(
       return;
     }
 
-    const projectKey = entity.metadata.annotations?.[PROJECT_KEY_ANNOTATION]!;
+    const projectKey =
+      entity.metadata.annotations?.[
+        `${annotationPrefix}/${PROJECT_KEY_ANNOTATION}`
+      ]!;
 
     const projectResponse = await getProjectResponse(projectKey, config, cache);
 

--- a/plugins/jira-dashboard-common/api-report.md
+++ b/plugins/jira-dashboard-common/api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 // @public
-export const COMPONENT_ANNOTATION = 'components';
+export const COMPONENTS_NAME = 'components';
 
 // @public
 export type Filter = {
@@ -14,7 +14,7 @@ export type Filter = {
 };
 
 // @public
-export const FILTER_ANNOTATION = 'filter-ids';
+export const FILTERS_NAME = 'filter-ids';
 
 // @public
 export type Issue = {
@@ -70,5 +70,5 @@ export type Project = {
 };
 
 // @public
-export const PROJECT_KEY_ANNOTATION = 'project-key';
+export const PROJECT_KEY_NAME = 'project-key';
 ```

--- a/plugins/jira-dashboard-common/api-report.md
+++ b/plugins/jira-dashboard-common/api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 // @public
-export const COMPONENT_ANNOTATION = 'jira.com/components';
+export const COMPONENT_ANNOTATION = 'components';
 
 // @public
 export type Filter = {
@@ -14,7 +14,7 @@ export type Filter = {
 };
 
 // @public
-export const FILTER_ANNOTATION = 'jira.com/filter-ids';
+export const FILTER_ANNOTATION = 'filter-ids';
 
 // @public
 export type Issue = {
@@ -70,5 +70,5 @@ export type Project = {
 };
 
 // @public
-export const PROJECT_KEY_ANNOTATION = 'jira.com/project-key';
+export const PROJECT_KEY_ANNOTATION = 'project-key';
 ```

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -3,16 +3,16 @@
  *
  *  @public
  */
-export const PROJECT_KEY_ANNOTATION = 'jira.com/project-key';
+export const PROJECT_KEY_ANNOTATION = 'project-key';
 
 /**
  * Jira components to track for this entity
  *  @public
  */
-export const COMPONENT_ANNOTATION = 'jira.com/components';
+export const COMPONENT_ANNOTATION = 'components';
 
 /**
  * Jira filter ids to track for this entity
  *  @public
  */
-export const FILTER_ANNOTATION = 'jira.com/filter-ids';
+export const FILTER_ANNOTATION = 'filter-ids';

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -1,18 +1,18 @@
 /**
- * The key of the Jira project to track for this entity
+ * The annotation name used to provide the key of the Jira project to track for this entity
  *
  *  @public
  */
-export const PROJECT_KEY_ANNOTATION = 'project-key';
+export const PROJECT_KEY_NAME = 'project-key';
 
 /**
- * Jira components to track for this entity
+ * The annotation name used to provide the Jira components to track for this entity
  *  @public
  */
-export const COMPONENT_ANNOTATION = 'components';
+export const COMPONENTS_NAME = 'components';
 
 /**
- * Jira filter ids to track for this entity
+ * The annotation name used to provide the Jira filter ids to track for this entity
  *  @public
  */
-export const FILTER_ANNOTATION = 'filter-ids';
+export const FILTERS_NAME = 'filter-ids';

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -43,7 +43,7 @@ const defaultEntityPage = (
 );
 ```
 
-OPTIONAL: The function `isJiraDashboardAvailable` checks for the annotation `axis.com`. You can choose to check for other existing annotation by padding the prop `annotationPrefix` into the function. See example below.
+OPTIONAL: The function `isJiraDashboardAvailable` checks for the annotation `axis.com`. You can choose to check for another annotation by passing the prop `annotationPrefix` into the function. See example below.
 
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -29,6 +29,23 @@ yarn --cwd packages/app add @axis-backstage/plugin-jira-dashboard
 
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx
+import { EntityJiraDashboardContent} from '@axis-backstage/plugin-jira-dashboard';
+
+const defaultEntityPage = (
+  <EntityLayout.Route
+    path="/jira-dashboard"
+    title="Jira Dashboard"
+  >
+    <EntityJiraDashboardContent />
+  </EntityLayout.Route>
+  ...
+);
+```
+
+OPTIONAL: You can choose to only display the Jira Dashboard tab if a specific annotation is available in the entity. The example below checks how to use the `isJiraDashboardAvailable` function to check for the `jira.com` annotation. It is also possible to define a custom function to check for other annotations.
+
+```tsx
+// In packages/app/src/components/catalog/EntityPage.tsx
 import { EntityJiraDashboardContent, isJiraDashboardAvailable } from '@axis-backstage/plugin-jira-dashboard';
 
 const defaultEntityPage = (

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -43,7 +43,7 @@ const defaultEntityPage = (
 );
 ```
 
-OPTIONAL: The function `isJiraDashboardAvailable` checks for the annotation `axis.com`. You can choose to check for another annotation by passing the prop `annotationPrefix` into the function. See example below.
+OPTIONAL: The function `isJiraDashboardAvailable` checks for the annotation `jira.com`. You can choose to check for another annotation by passing the prop `annotationPrefix` into the function. See example below.
 
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -29,10 +29,11 @@ yarn --cwd packages/app add @axis-backstage/plugin-jira-dashboard
 
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx
-import { EntityJiraDashboardContent} from '@axis-backstage/plugin-jira-dashboard';
+import { EntityJiraDashboardContent, isJiraDashboardAvailable } from '@axis-backstage/plugin-jira-dashboard';
 
 const defaultEntityPage = (
   <EntityLayout.Route
+    if={isJiraDashboardAvailable}
     path="/jira-dashboard"
     title="Jira Dashboard"
   >
@@ -42,7 +43,7 @@ const defaultEntityPage = (
 );
 ```
 
-OPTIONAL: You can choose to only display the Jira Dashboard tab if a specific annotation is available in the entity. The example below checks how to use the `isJiraDashboardAvailable` function to check for the `jira.com` annotation. It is also possible to define a custom function to check for other annotations.
+OPTIONAL: The function `isJiraDashboardAvailable` checks for the annotation `axis.com`. You can choose to check for other existing annotation by padding the prop `annotationPrefix` into the function. See example below.
 
 ```tsx
 // In packages/app/src/components/catalog/EntityPage.tsx
@@ -50,7 +51,7 @@ import { EntityJiraDashboardContent, isJiraDashboardAvailable } from '@axis-back
 
 const defaultEntityPage = (
   <EntityLayout.Route
-    if={isJiraDashboardAvailable}
+    if={entity => isJiraDashboardAvailable(entity, 'jira')}
     path="/jira-dashboard"
     title="Jira Dashboard"
   >

--- a/plugins/jira-dashboard/api-report.md
+++ b/plugins/jira-dashboard/api-report.md
@@ -14,7 +14,10 @@ import { RouteRef } from '@backstage/core-plugin-api';
 export const EntityJiraDashboardContent: () => JSX_2.Element;
 
 // @public
-export const isJiraDashboardAvailable: (entity: Entity) => boolean;
+export const isJiraDashboardAvailable: (
+  entity: Entity,
+  annotationPrefix?: string,
+) => boolean;
 
 // @public
 export const jiraDashboardPlugin: BackstagePlugin<

--- a/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
@@ -6,9 +6,6 @@ export const jiraDashboardApiRef = createApiRef<JiraDashboardApi>({
 });
 
 export type JiraDashboardApi = {
-  getJiraResponseByEntity(
-    entityRef: string,
-    projectKey: string,
-  ): Promise<JiraResponse>;
+  getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
   getProjectAvatar(entityRef: string): any;
 };

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -17,21 +17,17 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { jiraDashboardApiRef } from '../../api';
 import { useJira } from '../../hooks/useJira';
-import {
-  JiraDataResponse,
-  PROJECT_KEY_ANNOTATION,
-} from '@axis-backstage/plugin-jira-dashboard-common';
+import { JiraDataResponse } from '@axis-backstage/plugin-jira-dashboard-common';
 
 export const JiraDashboardContent = () => {
   const { entity } = useEntity();
-  const projectKey = entity?.metadata.annotations?.[PROJECT_KEY_ANNOTATION]!;
   const api = useApi(jiraDashboardApiRef);
 
   const {
     data: jiraResponse,
     loading,
     error,
-  } = useJira(stringifyEntityRef(entity), projectKey, api);
+  } = useJira(stringifyEntityRef(entity), api);
 
   if (loading) {
     return <Progress />;
@@ -41,7 +37,7 @@ export const JiraDashboardContent = () => {
     return (
       <ResponseErrorPanel
         error={Error(
-          `Could not fetch Jira Dashboard content for project key: ${projectKey}`,
+          'Could not fetch Jira Dashboard content for defined project key',
         )}
       />
     );

--- a/plugins/jira-dashboard/src/hooks/useJira.ts
+++ b/plugins/jira-dashboard/src/hooks/useJira.ts
@@ -4,7 +4,6 @@ import { JiraDashboardApi } from '../api';
 
 export function useJira(
   entityRef: string,
-  projectKey: string,
   jiraDashboardApi: JiraDashboardApi,
 ): {
   data: JiraResponse | undefined;
@@ -16,10 +15,7 @@ export function useJira(
     loading,
     error,
   } = useAsync(async (): Promise<any> => {
-    const response = await jiraDashboardApi.getJiraResponseByEntity(
-      entityRef,
-      projectKey,
-    );
+    const response = await jiraDashboardApi.getJiraResponseByEntity(entityRef);
     response.project.avatarUrls = await jiraDashboardApi.getProjectAvatar(
       entityRef,
     );

--- a/plugins/jira-dashboard/src/plugin.ts
+++ b/plugins/jira-dashboard/src/plugin.ts
@@ -15,8 +15,15 @@ import { JiraDashboardClient, jiraDashboardApiRef } from './api';
  * @public
  * @param entity - The entity to check for the jira.com project-key annotation.
  */
-export const isJiraDashboardAvailable = (entity: Entity) =>
-  Boolean(entity.metadata.annotations?.[`jira.com/${PROJECT_KEY_ANNOTATION}`]);
+export const isJiraDashboardAvailable = (
+  entity: Entity,
+  annotationPrefix?: string,
+) =>
+  Boolean(
+    entity.metadata.annotations?.[
+      `${annotationPrefix ?? 'jira.com'}/${PROJECT_KEY_ANNOTATION}`
+    ],
+  );
 
 /**
  * Plugin that provides the Jira Dashboard api

--- a/plugins/jira-dashboard/src/plugin.ts
+++ b/plugins/jira-dashboard/src/plugin.ts
@@ -16,7 +16,7 @@ import { JiraDashboardClient, jiraDashboardApiRef } from './api';
  * @param entity - The entity to check for the jira.com project-key annotation.
  */
 export const isJiraDashboardAvailable = (entity: Entity) =>
-  Boolean(entity.metadata.annotations?.[PROJECT_KEY_ANNOTATION]);
+  Boolean(entity.metadata.annotations?.[`jira.com/${PROJECT_KEY_ANNOTATION}`]);
 
 /**
  * Plugin that provides the Jira Dashboard api

--- a/plugins/jira-dashboard/src/plugin.ts
+++ b/plugins/jira-dashboard/src/plugin.ts
@@ -7,7 +7,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { rootRouteRef } from './routes';
 import { Entity } from '@backstage/catalog-model';
-import { PROJECT_KEY_ANNOTATION } from '@axis-backstage/plugin-jira-dashboard-common';
+import { PROJECT_KEY_NAME } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraDashboardClient, jiraDashboardApiRef } from './api';
 
 /**
@@ -21,7 +21,7 @@ export const isJiraDashboardAvailable = (
 ) =>
   Boolean(
     entity.metadata.annotations?.[
-      `${annotationPrefix ?? 'jira.com'}/${PROJECT_KEY_ANNOTATION}`
+      `${annotationPrefix ?? 'jira.com'}/${PROJECT_KEY_NAME}`
     ],
   );
 


### PR DESCRIPTION
### Describe your changes

Support for custom annotationPrefix has been added to both Jira Dashboard frontend and backend. It is now possible to define other annotations than 'jira.com' (for example 'jira' that is used in many of existing catalog files based on Roadies' definition).

Changes in backend:
* Annotation prefix value has been added to config
* If no annotation prefix is provided, 'jira.com' is used as default.

Changes in frontend:
* The function isJiraDashboardAvailable used on EntityPage now takes in optional parameter 'annotationPrefix'. If no annotation prefix is provided, 'jira.com' is used.

Changes in common-plugin:
* Updated annotations so the prefix is not provided with the annotation. For instance¸ changed 'jira.com/project-key' to 'project-key'. 

### Issue ticket number and link

- Fixes #48 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
