### PR TITLE
Add more noticeable backend instructions in README.md

### DIFF
--- a/.changeset/polite-rocks-kiss.md
+++ b/.changeset/polite-rocks-kiss.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+'@axis-backstage/plugin-readme': patch
+---
+
+Updated the notes in the README.md about backend installation and setup in Jira Dashboard plugin and README plugin

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -12,9 +12,9 @@ This plugin supports both **Jira Software** and **Jira Cloud**.
 
 By default, the issue views that are provided are **incoming issues**, **open issues** and **assigned to you**.
 
-## Note
+## Jira Dashboard backend
 
-You will **need** to also perform the installation instructions in [Jira Dashboard Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard-backend) in order for this plugin to work.
+You **need** to set up the [Jira Dashboard Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard-backend) plugin before you move forward with any of these steps if you haven't already.
 
 ## Getting Started
 

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -20,9 +20,9 @@ The displays README files with one of the following file types: **md**, **MD**, 
 
 Currently, placing your README.md file elsewhere than in the same directory as the `catalog-info.yaml file` repository is not supported.
 
-## Note
+## Readme Backend
 
-You will **need** to also perform the installation instructions in [Readme Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme-backend) in order for this plugin to work.
+You **need** to set up the [Readme Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme-backend) plugin before you move forward with any of these steps if you haven't already.
 
 ## Getting started
 


### PR DESCRIPTION
### Describe your changes

In the instructions for the frontend plugins the info about that the backend plugins need to be installed too could easily be missed. Therefore, the README.md has been updated for both Jira Dashboard and the Readme-plugin.

The text is now:
```
## Jira Dashboard backend

You **need** to set up the [Jira Dashboard Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard-backend) plugin before you move forward with any of these steps if you haven't already.

```

```
## Readme Backend

You **need** to set up the [Readme Backend](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme-backend) plugin before you move forward with any of these steps if you haven't already.

```
### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that my code follows the style already available in the repository
