### PR TITLE
Add support for Roadies /component annotation

### DIFF
--- a/.changeset/large-masks-wait.md
+++ b/.changeset/large-masks-wait.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+The Jira Dashboard backend now also looks for the `/component`-annotation, in order to support Roadies annotation.

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -13,9 +13,13 @@ export const getAnnotations = (config: Config) => {
   const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
   const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
 
+  /*   Adding support for Roadie's component annotation */
+  const componentRoadieAnnotation = `${prefix}/component`;
+
   return {
     projectKeyAnnotation,
     componentsAnnotation,
+    componentRoadieAnnotation,
     filtersAnnotation,
   };
 };

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -89,8 +89,12 @@ export async function createRouter(
       const entityRef = request.params.entityRef;
       const { token } = await tokenManager.getToken();
       const entity = await catalogClient.getEntityByRef(entityRef, { token });
-      const { projectKeyAnnotation, componentsAnnotation, filtersAnnotation } =
-        getAnnotations(config);
+      const {
+        projectKeyAnnotation,
+        componentsAnnotation,
+        componentRoadieAnnotation,
+        filtersAnnotation,
+      } = getAnnotations(config);
 
       if (!entity) {
         logger.info(`No entity found for ${entityRef}`);
@@ -148,7 +152,12 @@ export async function createRouter(
       const componentAnnotations =
         entity.metadata.annotations?.[componentsAnnotation]?.split(',')!;
 
-      if (componentAnnotations) {
+      /*   Adding support for Roadie's component annotation */
+      const allComponentAnnotations = componentAnnotations.concat(
+        entity.metadata.annotations?.[componentRoadieAnnotation]?.split(',')!,
+      );
+
+      if (allComponentAnnotations) {
         const componentIssues = await getIssuesFromComponents(
           projectKey,
           componentAnnotations,

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -149,18 +149,19 @@ export async function createRouter(
 
       let issues = await getIssuesFromFilters(projectKey, filters, config);
 
-      const componentAnnotations =
-        entity.metadata.annotations?.[componentsAnnotation]?.split(',')!;
+      let components =
+        entity.metadata.annotations?.[componentsAnnotation]?.split(',') ?? [];
 
       /*   Adding support for Roadie's component annotation */
-      const allComponentAnnotations = componentAnnotations.concat(
-        entity.metadata.annotations?.[componentRoadieAnnotation]?.split(',')!,
+      components = components.concat(
+        entity.metadata.annotations?.[componentRoadieAnnotation]?.split(',') ??
+          [],
       );
 
-      if (allComponentAnnotations) {
+      if (components) {
         const componentIssues = await getIssuesFromComponents(
           projectKey,
-          componentAnnotations,
+          components,
           config,
         );
         issues = issues.concat(componentIssues);

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -85,7 +85,7 @@ metadata:
   # ...
   annotations:
     jira.com/project-key: value # The key of the Jira project to track for this entity
-    jira.com/components: component,component,component # Jira component name separated with a comma
+    jira.com/components: component,component,component # Jira component name separated with a comma. The Roadie Backstage Jira Plugin Jira annotation `/component` is also supported here by default
     jira.com/filter-ids: 12345,67890 # Jira filter id separated with a comma
 ```
 


### PR DESCRIPTION
### Describe your changes

In the Jira Dashboard plugin, many of our users already have the Roadie /component annotation in their catalog files. By also supporting this annotation by default, these users will not need to add an additional annotation for defining Jira components. 

Changes:
- Jira Dashboard backend now checks for existing Roadie /component annotation. If there is one, those defined components are also added to the Jira Dashboard.

### Issue ticket number and link

- Fixes #48 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
