### PR TITLE
Improved Jira-Dashboard APIs

### DIFF
--- a/.changeset/clever-dingos-film.md
+++ b/.changeset/clever-dingos-film.md
@@ -3,4 +3,4 @@
 '@axis-backstage/plugin-jira-dashboard': minor
 ---
 
-Dashboard and Avatar backend APIs adjusted to consume entityRef as /:kind/:namespace/:name. Fixes issue with proxies such as oauth2Proxy from decoding the URI encodedpath parameter /:entityRef known to contain the path delimiter '/'.
+Dashboard and Avatar backend APIs adjusted to consume entityRef as /:kind/:namespace/:name. Fixes a 404 routing issue where a proxy like oauth2Proxy could decode the URI encoded path parameter /:entityRef known to contain the reserved path delimiter '/'.

--- a/.changeset/clever-dingos-film.md
+++ b/.changeset/clever-dingos-film.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Dashboard and Avatar backend APIs adjusted to consume entityRef as /:kind/:namespace/:name. Fixes issue with proxies such as oauth2Proxy from decoding the URI encodedpath parameter /:entityRef known to contain the path delimiter '/'.

--- a/plugins/jira-dashboard-backend/package.json
+++ b/plugins/jira-dashboard-backend/package.json
@@ -26,6 +26,7 @@
     "@backstage/backend-common": "^0.20.1",
     "@backstage/backend-plugin-api": "^0.6.9",
     "@backstage/catalog-client": "^1.5.2",
+    "@backstage/catalog-model": "^1.4.3",
     "@backstage/config": "^1.1.1",
     "@backstage/plugin-auth-node": "^0.4.3",
     "@backstage/plugin-permission-common": "^0.7.12",

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -3,6 +3,7 @@ import {
   TokenManager,
   errorHandler,
 } from '@backstage/backend-common';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Config } from '@backstage/config';
@@ -84,9 +85,10 @@ export async function createRouter(
   });
 
   router.get(
-    '/dashboards/by-entity-ref/:entityRef',
+    '/dashboards/by-entity-ref/:kind/:namespace/:name',
     async (request, response) => {
-      const entityRef = request.params.entityRef;
+      const { kind, namespace, name } = request.params;
+      const entityRef = stringifyEntityRef({ kind, namespace, name });
       const { token } = await tokenManager.getToken();
       const entity = await catalogClient.getEntityByRef(entityRef, { token });
       const { projectKeyAnnotation, componentsAnnotation, filtersAnnotation } =
@@ -165,8 +167,9 @@ export async function createRouter(
     },
   );
 
-  router.get('/avatar/by-entity-ref/:entityRef', async (request, response) => {
-    const { entityRef } = request.params;
+  router.get('/avatar/by-entity-ref/:kind/:namespace/:name', async (request, response) => {
+    const { kind, namespace, name } = request.params;
+    const entityRef = stringifyEntityRef({ kind, namespace, name });
     const { token } = await tokenManager.getToken();
     const entity = await catalogClient.getEntityByRef(entityRef, { token });
     const { projectKeyAnnotation } = getAnnotations(config);

--- a/plugins/jira-dashboard/dev/__fixtures__/jiraCloudResponse.json
+++ b/plugins/jira-dashboard/dev/__fixtures__/jiraCloudResponse.json
@@ -62,7 +62,7 @@
       "Administrators": "https://issues.jenkins.io/rest/api/2/project/10200/role/10002",
       "Users": "https://issues.jenkins.io/rest/api/2/project/10200/role/10000"
     },
-    "avatarUrls": "http://localhost:7007/api/jira-dashboard/avatar/by-entity-ref/component%3Adefault%2Fexample-website",
+    "avatarUrls": "http://localhost:7007/api/jira-dashboard/avatar/by-entity-ref/component/default/example-website",
     "projectTypeKey": "software",
     "archived": false
   },

--- a/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
@@ -33,6 +33,9 @@ export class JiraDashboardClient implements JiraDashboardApi {
 
   async getProjectAvatar(entityRef: string): Promise<string> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
+    const { kind, name, namespace } = parseEntityRef(entityRef, {
+      defaultNamespace: DEFAULT_NAMESPACE,
+    });
     return `${apiUrl}/avatar/by-entity-ref/${kind}/${namespace}/${name}`;
   }
 }

--- a/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
@@ -2,6 +2,7 @@ import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { JiraResponse } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraDashboardApi } from './JiraDashboardApi';
 import { ResponseError } from '@backstage/errors';
+import { DEFAULT_NAMESPACE, parseEntityRef } from '@backstage/catalog-model';
 
 export class JiraDashboardClient implements JiraDashboardApi {
   private readonly discoveryApi: DiscoveryApi;
@@ -14,8 +15,11 @@ export class JiraDashboardClient implements JiraDashboardApi {
 
   async getJiraResponseByEntity(entityRef: string): Promise<JiraResponse> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
+    const { kind, name, namespace } = parseEntityRef(entityRef, {
+      defaultNamespace: DEFAULT_NAMESPACE,
+    });
     const resp = await this.fetchApi.fetch(
-      `${apiUrl}/dashboards/by-entity-ref/${encodeURIComponent(entityRef)}`,
+      `${apiUrl}/dashboards/by-entity-ref/${kind}/${namespace}/${name}`,
       {
         method: 'GET',
         headers: {
@@ -29,6 +33,6 @@ export class JiraDashboardClient implements JiraDashboardApi {
 
   async getProjectAvatar(entityRef: string): Promise<string> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
-    return `${apiUrl}/avatar/by-entity-ref/${encodeURIComponent(entityRef)}`;
+    return `${apiUrl}/avatar/by-entity-ref/${kind}/${namespace}/${name}`;
   }
 }

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
@@ -27,10 +27,10 @@ describe('JiraDashboardContent', () => {
   const setupHandlers = () => {
     server.use(
       rest.get(
-        `${mockBaseUrl}/dashboards/by-entity-ref/:entityRef`,
+        `${mockBaseUrl}/dashboards/by-entity-ref/:kind/:namespace/:name`,
         (req, res, ctx) => {
-          const { entityRef } = req.params;
-          if (entityRef) {
+          const { kind, namespace, name } = req.params;
+          if (kind && namespace && name) {
             return res(ctx.json(mockedJiraResponse));
           }
           return res(ctx.status(400));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,6 +1015,7 @@ __metadata:
     "@backstage/backend-common": "npm:^0.20.1"
     "@backstage/backend-plugin-api": "npm:^0.6.9"
     "@backstage/catalog-client": "npm:^1.5.2"
+    "@backstage/catalog-model": "npm:^1.4.3"
     "@backstage/cli": "npm:^0.25.1"
     "@backstage/config": "npm:^1.1.1"
     "@backstage/plugin-auth-node": "npm:^0.4.3"


### PR DESCRIPTION
### Describe your changes

The plugin works great locally and a huge improvement over Roadie's plugin, but when it is deployed behind my auth proxy service, the /:entityref path parameter gets decoded and then the backend fails to find a matching URI path. This is what happens:

UI fetches:
`/api/jira-dashboard/avatar/by-entity-ref/component%3Adefault%2Fexample-website`

Backend URI received:
`/api/jira-dashboard/avatar/by-entity-ref/component:default/example-website`

so express is trying to match a route for something like the below APIs, but can't find it and responds with a 404:
/api/jira-dashboard/avatar/by-entity-ref/:entityref/example-website
/api/jira-dashboard/avatar/by-entity-ref/:entityref/:name

where ":entityref == "component:default"

Technically speaking, RFC3986 section 2.2 explains the risks of encoding reserved characters such as '/' in the URI path:

> The purpose of reserved characters is to provide a set of delimiting
   characters that are distinguishable from other data within a URI.
   URIs that differ in the replacement of a reserved character with its
   corresponding percent-encoded octet are not equivalent.  Percent-
   encoding a reserved character, or decoding a percent-encoded octet
   that corresponds to a reserved character, will change how the URI is
   interpreted by most applications.

Reference:
https://datatracker.ietf.org/doc/html/rfc3986#section-2.2

proof this works on my install:
<img width="855" alt="Screenshot 2024-02-11 at 1 02 07 AM" src="https://github.com/AxisCommunications/backstage-plugins/assets/23493031/3a8304a8-5536-47fd-8b49-047f061e1524">
<img width="1558" alt="Screenshot 2024-02-11 at 1 03 23 AM" src="https://github.com/AxisCommunications/backstage-plugins/assets/23493031/abce68bf-d83b-45be-92fe-b51f463ef6d8">

### Issue

fixes #76 

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
