### PR TITLE
Fix routing for StatuspageEntityCard

### DIFF
--- a/.changeset/tasty-falcons-guess.md
+++ b/.changeset/tasty-falcons-guess.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-statuspage': minor
+---
+
+StatuspageEntityCard was route mounted incorrectly, which broke the component in certain cases.

--- a/plugins/statuspage/README.md
+++ b/plugins/statuspage/README.md
@@ -6,11 +6,11 @@ Welcome to the Statuspage.io plugin!
 
 The **Statuspage** plugin allows you to embedd https://statuspage.io components, component groups and dashboards in Backstage.
 
-There is a React-card, `<StatuspageEntityComponent />`, that is suitable for the Entity component/service overview page:
+There is a React-card, `<StatuspageEntityCard />`, that is suitable for the Entity component/service overview page:
 
 ![entity-card](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/statuspage/media/entity-card.png)
 
-And also one card, `<StatuspageComponent instance="myinstance"/>`, for easy integration of a complete Statuspage. This component is _not_ dependent
+And also one card, `<StatuspagePage name="myinstance"/>`, for easy integration of a complete Statuspage. This component is _not_ dependent
 on the `useEntity()`-hook, making it easy to integrate on the Home-page (or some other portal).
 
 ![full-status](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/statuspage/media/full-status.png)
@@ -50,7 +50,7 @@ const defaultEntityPage = (
       <EntitySwitch>
         <EntitySwitch.Case if={isStatuspageAvailable}>
           <Grid item xs={12}>
-            <StatuspageEntityComponent />
+            <StatuspageEntityCard />
           </Grid>
         </EntitySwitch.Case>
       </EntitySwitch>

--- a/plugins/statuspage/api-report.md
+++ b/plugins/statuspage/api-report.md
@@ -8,13 +8,14 @@
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { JSX as JSX_2 } from 'react';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public
 export const isStatuspageAvailable: (entity: Entity) => boolean;
 
 // @public
-export const StatuspageEntityCard: () => JSX_2.Element;
+export const StatuspageEntityCard: () => React_2.JSX.Element;
 
 // @public
 export const StatuspagePage: ({ name }: StatuspageProps) => JSX_2.Element;

--- a/plugins/statuspage/src/components/StatuspageEntityCard.tsx
+++ b/plugins/statuspage/src/components/StatuspageEntityCard.tsx
@@ -19,7 +19,7 @@ import { useComponents } from '../hooks/useComponents';
  *
  * @public
  */
-export const StatuspageEntityComponent = () => {
+export const StatuspageEntityCard = () => {
   const { entity } = useEntity();
   const [name, wantedComponentsStr] =
     entity.metadata.annotations?.[STATUSPAGE_ANNOTATION]?.split(':')!;

--- a/plugins/statuspage/src/components/index.ts
+++ b/plugins/statuspage/src/components/index.ts
@@ -1,4 +1,4 @@
-export { StatuspageEntityComponent } from './StatuspageEntityComponent';
+export { StatuspageEntityCard } from './StatuspageEntityCard';
 export { ComponentGroupCard } from './ComponentGroupCard';
 export { ComponentGroupsList } from './ComponentGroupsList';
 export { ComponentsTable } from './ComponentsTable';

--- a/plugins/statuspage/src/index.ts
+++ b/plugins/statuspage/src/index.ts
@@ -7,6 +7,6 @@ export {
   isStatuspageAvailable,
   statuspagePlugin,
   StatuspagePage,
-  StatuspageEntityCard,
 } from './plugin';
 export type { StatuspageProps } from './components';
+export { StatuspageEntityCard } from './components';

--- a/plugins/statuspage/src/plugin.ts
+++ b/plugins/statuspage/src/plugin.ts
@@ -59,19 +59,3 @@ export const StatuspagePage = statuspagePlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
-
-/**
- * Routable extension for StatuspageComponent.
- *
- * @public
- */
-export const StatuspageEntityCard = statuspagePlugin.provide(
-  createRoutableExtension({
-    name: 'StatuspageEntityCard',
-    component: () =>
-      import('./components/StatuspageEntityComponent').then(
-        m => m.StatuspageEntityComponent,
-      ),
-    mountPoint: rootRouteRef,
-  }),
-);


### PR DESCRIPTION
StatuspageEntityCard should not have a route
mountpoint. Especially not the same as
StatuspagePage.

By removing the routableExtension for
StatuspageEntityCard, we get rid of some weird
routing conflicts.

Instead we export the component directly as
StatuspageEntityCard.

This also updates the README.md for statuspage
to reflect the actual name of the component.

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation

