### PR TITLE
Dialog

### DIFF
--- a/.changeset/late-adults-switch.md
+++ b/.changeset/late-adults-switch.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme': patch
+---
+
+Fixed so that Readme Dialog always have a min width. In that case, if it is not smuch markdown content, the dialog wont be weirdly small.

--- a/plugins/readme/dev/index.tsx
+++ b/plugins/readme/dev/index.tsx
@@ -22,8 +22,10 @@ createDevApp()
     element: (
       <Content>
         <EntityProvider entity={mockEntity}>
-          <Grid md={6} xs={12}>
-            <ReadmeCard />
+          <Grid container>
+            <Grid md={6} xs={6}>
+              <ReadmeCard />
+            </Grid>
           </Grid>
         </EntityProvider>
       </Content>

--- a/plugins/readme/src/components/ReadmeDialog/ReadmeDialog.tsx
+++ b/plugins/readme/src/components/ReadmeDialog/ReadmeDialog.tsx
@@ -4,6 +4,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import Box from '@mui/material/Box';
 import { FetchComponent } from '../FetchComponent';
 
 type Props = {
@@ -21,7 +22,9 @@ export const ReadmeDialog = ({ open, onClose }: Props) => {
     >
       <DialogTitle>README</DialogTitle>
       <DialogContent dividers>
-        <FetchComponent />
+        <Box minWidth={650}>
+          <FetchComponent />
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button


### PR DESCRIPTION
### Describe your changes

When there is not so much content inside the Readme dialog, it was very small which looked a bit weird. In this PR, the following changes has been made:

- A min width has been added to the ReadmeDialog. No matter the content, the dialog will always be min 650.
- In development mode, (running yarn start inside the plugin), the card is now md 6 instead of 12. This by adding it inside a container. 

### Screenshots

#### Before:
![Screenshot from 2024-02-16 15-05-44](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/f8a2328d-713f-4b97-b7b7-9acdb7738565)

#### After:
![Screenshot from 2024-02-16 15-07-23](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/67d16ad2-20fc-4ed0-ba6a-d8264b4ca575)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
