### PR TITLE
Only display scrollbar if it is used

### DIFF
--- a/.changeset/lazy-apples-hammer.md
+++ b/.changeset/lazy-apples-hammer.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+The scroll behavior on JiraTable have been set to auto, in order to only display the scrollbar if it is used. Otherwise, it is hidden.

--- a/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
@@ -42,7 +42,7 @@ export const JiraTable = ({ tableContent }: Props) => {
       style={{
         height: '500px',
         padding: '20px',
-        overflowY: 'scroll',
+        overflowY: 'auto',
         width: '100%',
       }}
     />


### PR DESCRIPTION
### Describe your changes

In JiraTable in the Jira Dashboard plugin, the following changes has been made:

- Instead of always showing the scrollbars, they are only displayed if the content overflows. This is changed to make the tables look better.

### Screenshots

#### Before
![Screenshot from 2024-02-19 14-45-08](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/fa98d24e-5b74-4b21-8ce2-773dd3a2e4ef)

#### After
![Screenshot from 2024-02-19 14-44-58](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/9ee595f0-6979-4afc-9996-2b2f5bd3e605)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
