### PR TITLE
Fix ci-release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn github-release
+          publish: yarn publish:github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ local_examples/
 
 # No distribution files
 **/package.tgz
+
+# no npm _release-folders
+**/_release
+

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
+    "pack": "yarn workspaces foreach -A -v pack",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "release": "changeset version && yarn prettier --write '{packages,plugins}/*/package.json' && yarn install --no-immutable",
-    "github-release": "yarn tsc && yarn build:all && yarn workspaces foreach -A -v pack && changeset publish",
+    "publish:prepare": "yarn workspaces foreach -A pack && yarn workspaces foreach -A exec \"rm -rf _release && mkdir _release && tar zxvf package.tgz --directory _release && rm package.tgz\"",
+    "publish:github": "yarn tsc && yarn build:all && yarn publish:prepare && changeset publish",
     "new": "backstage-cli new --scope internal"
   },
   "workspaces": {


### PR DESCRIPTION
`changeset publish` calls `npm publish`, which in
turns accepts a _release folder as the package to
publish.

Generate the actual release files using `yarn pack`
to ensure the package.json in the npm packages are
correct.

Code was tested against a staging npm repo.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
