### PR TITLE
Refactor: Update default project lead name from 'key' to 'displayName' for clarity and consistency

### DIFF
--- a/.changeset/gold-geese-perform.md
+++ b/.changeset/gold-geese-perform.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Refactor: Update default project lead name from 'key' to 'displayName' for clarity and consistency.

--- a/plugins/jira-dashboard/src/components/JiraProjectCard/JiraProjectCard.tsx
+++ b/plugins/jira-dashboard/src/components/JiraProjectCard/JiraProjectCard.tsx
@@ -40,9 +40,13 @@ export const JiraProjectCard = ({ project }: JiraProjectCardProps) => {
         {project.description && (
           <ProjectInfoLabel label="Description" value={project.description} />
         )}
-        {project.lead?.key && (
-          <ProjectInfoLabel label="Project lead" value={project.lead.key} />
-        )}
+        {project.lead?.key ||
+          (project?.lead?.displayName && (
+            <ProjectInfoLabel
+              label="Project lead"
+              value={project?.lead?.displayName || project?.lead?.key}
+            />
+          ))}
       </Stack>
       <LinkButton
         color="primary"


### PR DESCRIPTION
This commit enhances readability by replacing default the ambiguous 'key' with the descriptive 'displayName' for the project lead name.

### Describe your changes

1. switched the defullt key to displayName for project lead field

### Issue ticket number and link

- Fixes #100 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
