### PR TITLE
Release flow: Missing publish directory option

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "release": "changeset version && yarn prettier --write '{packages,plugins}/*/package.json' && yarn install --no-immutable",
-    "publish:prepare": "yarn workspaces foreach -A pack && yarn workspaces foreach -A exec \"rm -rf _release && mkdir _release && tar zxvf package.tgz --directory _release && rm package.tgz\"",
+    "publish:prepare": "yarn workspaces foreach --no-private -A pack && yarn workspaces foreach --no-private -A exec \"rm -rf _release && mkdir _release && tar zxvf package.tgz --directory _release && rm package.tgz\"",
     "publish:github": "yarn tsc && yarn build:all && yarn publish:prepare && changeset publish",
     "new": "backstage-cli new --scope internal"
   },

--- a/plugins/analytics-module-umami/package.json
+++ b/plugins/analytics-module-umami/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "frontend-plugin"

--- a/plugins/jira-dashboard-backend/package.json
+++ b/plugins/jira-dashboard-backend/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/jira-dashboard-common/package.json
+++ b/plugins/jira-dashboard-common/package.json
@@ -9,7 +9,8 @@
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "common-library"

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "frontend-plugin"

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/readme/package.json
+++ b/plugins/readme/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "frontend-plugin"

--- a/plugins/statuspage-backend/package.json
+++ b/plugins/statuspage-backend/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/statuspage-common/package.json
+++ b/plugins/statuspage-common/package.json
@@ -9,7 +9,8 @@
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "common-library"

--- a/plugins/statuspage/package.json
+++ b/plugins/statuspage/package.json
@@ -7,7 +7,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "directory": "_release/package"
   },
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
We need to point out the yarn generated package
directory to the publish.

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
