### PR TITLE
feat: allow max height to be overridden for readme plugin

### DIFF
--- a/.changeset/sharp-apricots-do.md
+++ b/.changeset/sharp-apricots-do.md
@@ -2,5 +2,4 @@
 '@axis-backstage/plugin-readme': minor
 ---
 
-Added an ability to provide max height for the readme box via new `maxHeight` property.
-By default the `maxHeight` is set to 235px and accept both string and number values, that is to support options as `none` to remove max height restriction.
+Updated the max height in case of variant `fullHeight` to be `none` by default. That is needed to really occupy the full height of the container.

--- a/.changeset/sharp-apricots-do.md
+++ b/.changeset/sharp-apricots-do.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-readme': minor
+---
+
+Added an ability to provide max height for the readme box via new `maxHeight` property.
+By default the `maxHeight` is set to 235px and accept both string and number values, that is to support options as `none` to remove max height restriction.

--- a/plugins/readme/api-report.md
+++ b/plugins/readme/api-report.md
@@ -16,7 +16,6 @@ export const ReadmeCard: (props: ReadmeCardProps) => JSX_2.Element;
 // @public
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
-  maxHeight?: string | number;
 };
 
 // @public

--- a/plugins/readme/api-report.md
+++ b/plugins/readme/api-report.md
@@ -11,11 +11,12 @@ import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public
-export const ReadmeCard: ({ variant }: ReadmeCardProps) => JSX_2.Element;
+export const ReadmeCard: (props: ReadmeCardProps) => JSX_2.Element;
 
 // @public
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
+  maxHeight?: string | number;
 };
 
 // @public

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -18,10 +18,7 @@ export type ReadmeCardProps = {
 };
 
 export const ReadmeCard = (props: ReadmeCardProps) => {
-  const {
-    variant = 'gridItem',
-    maxHeight = 235,
-  } = props;
+  const { variant = 'gridItem', maxHeight = 235 } = props;
 
   const [displayDialog, setDisplayDialog] = useState(false);
 

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -23,7 +23,6 @@ export const ReadmeCard = (props: ReadmeCardProps) => {
     maxHeight = 235,
   } = props;
 
-
   const [displayDialog, setDisplayDialog] = useState(false);
 
   return (

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -14,16 +14,23 @@ import { ReadmeDialog } from '../ReadmeDialog/ReadmeDialog';
 
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
+  maxHeight?: string | number;
 };
 
-export const ReadmeCard = ({ variant }: ReadmeCardProps) => {
+export const ReadmeCard = (props: ReadmeCardProps) => {
+  const {
+    variant = 'gridItem',
+    maxHeight = 235,
+  } = props;
+
+
   const [displayDialog, setDisplayDialog] = useState(false);
 
   return (
     <>
       <InfoCard
         title="README"
-        variant={variant || 'gridItem'}
+        variant={variant}
         action={
           variant !== 'fullHeight' ? (
             <IconButton
@@ -39,7 +46,7 @@ export const ReadmeCard = ({ variant }: ReadmeCardProps) => {
         }
       >
         <div style={{ overflow: 'auto' }}>
-          <Box maxHeight={variant !== 'fullHeight' ? 235 : 500}>
+          <Box maxHeight={maxHeight}>
             <FetchComponent />
           </Box>
         </div>

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -14,11 +14,11 @@ import { ReadmeDialog } from '../ReadmeDialog/ReadmeDialog';
 
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
-  maxHeight?: string | number;
 };
 
 export const ReadmeCard = (props: ReadmeCardProps) => {
-  const { variant = 'gridItem', maxHeight = 235 } = props;
+  const { variant = 'gridItem' } = props;
+  const maxHeight = variant === 'fullHeight' ? 'none' : '235px';
 
   const [displayDialog, setDisplayDialog] = useState(false);
 


### PR DESCRIPTION
### Describe your changes

Ability to override the max height of the box component of the readme plugin.

Current logic limits height to 2 options: 235 and 500 px which is very limited. The default value for 235 px left for backward compatibility of changes.

### Issue ticket number and link

- Fixes https://github.com/AxisCommunications/backstage-plugins/issues/110

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
