### PR TITLE
Add additional URL path to Jira links

### DIFF
--- a/.changeset/soft-readers-relax.md
+++ b/.changeset/soft-readers-relax.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Added the url pathname as part of the base URL for all links to Jira. This because Jira Server have additional path in the Jira base URl and links were broken.

--- a/plugins/jira-dashboard/src/lib.test.ts
+++ b/plugins/jira-dashboard/src/lib.test.ts
@@ -1,0 +1,60 @@
+import { getJiraBaseUrl, getProjectUrl, getIssueUrl } from './lib';
+
+const mockedProject = {
+  name: 'Backstage',
+  key: 'BS',
+  description: 'This is our Backstage project',
+  avatarUrls: {
+    '48x48': 'https://api.dicebear.com/6.x/open-peeps/svg?seed=Duane',
+  },
+  projectTypeKey: 'Software',
+  projectCategory: {
+    name: 'Software Portals',
+  },
+  lead: {
+    key: 'fridaja',
+    displayName: 'Frida Jacobsson',
+  },
+  self: 'https://jira.com/rest/api/2/project/123',
+};
+
+describe('getJiraBaseUrl', () => {
+  it('should return the base URL of a Jira instance', () => {
+    const baseUrl = 'https://jira.com/rest/api/2/project/123';
+    const expected = 'https://jira.com';
+    expect(getJiraBaseUrl(baseUrl)).toEqual(expected);
+  });
+
+  it('should handle URLs with additional paths', () => {
+    const baseUrl = 'https://jira.com/my-path/rest/api/2/project/123';
+    const expected = 'https://jira.com/my-path';
+    expect(getJiraBaseUrl(baseUrl)).toEqual(expected);
+  });
+});
+
+describe('getProjectUrl', () => {
+  it('should return the URL to a Jira project', () => {
+    const expected = 'https://jira.com/browse/BS';
+    expect(getProjectUrl(mockedProject)).toEqual(expected);
+  });
+  it('should handle URLs with additional paths', () => {
+    const expected = 'https://jira.com/my-path/browse/BS';
+    mockedProject.self = 'https://jira.com/my-path/rest/api/2/project/123';
+    expect(getProjectUrl(mockedProject)).toEqual(expected);
+  });
+});
+
+describe('getIssueUrl', () => {
+  it('should return the URL to an issue', () => {
+    const issueUrl = 'https://jira.com/rest/api/2/issue/123';
+    const issueKey = 'PROJ-123';
+    const expected = 'https://jira.com/browse/PROJ-123';
+    expect(getIssueUrl(issueUrl, issueKey)).toEqual(expected);
+  });
+  it('should handle URLs with additional paths', () => {
+    const issueUrl = 'https://jira.com/my-path/rest/api/2/issue/123';
+    const issueKey = 'PROJ-123';
+    const expected = 'https://jira.com/my-path/browse/PROJ-123';
+    expect(getIssueUrl(issueUrl, issueKey)).toEqual(expected);
+  });
+});

--- a/plugins/jira-dashboard/src/lib.ts
+++ b/plugins/jira-dashboard/src/lib.ts
@@ -1,6 +1,6 @@
 import { Project } from '@axis-backstage/plugin-jira-dashboard-common';
 
-const getJiraBaseUrl = (a: string) => {
+export const getJiraBaseUrl = (a: string) => {
   const url = new URL(a);
   const path = url.pathname.split('/rest/api/2/')[0];
   return url.origin + path;

--- a/plugins/jira-dashboard/src/lib.ts
+++ b/plugins/jira-dashboard/src/lib.ts
@@ -2,7 +2,7 @@ import { Project } from '@axis-backstage/plugin-jira-dashboard-common';
 
 export const getJiraBaseUrl = (a: string) => {
   const url = new URL(a);
-  const path = url.pathname.split('/rest/api/2/')[0];
+  const path = url.pathname.split('/rest/api')[0];
   return url.origin + path;
 };
 

--- a/plugins/jira-dashboard/src/lib.ts
+++ b/plugins/jira-dashboard/src/lib.ts
@@ -1,17 +1,21 @@
 import { Project } from '@axis-backstage/plugin-jira-dashboard-common';
 
+const getJiraBaseUrl = (a: string) => {
+  const url = new URL(a);
+  const path = url.pathname.split('/rest/api/2/')[0];
+  return url.origin + path;
+};
+
 /**
  * Get the URL to a Jira project.
  */
 export const getProjectUrl = (project: Project) => {
-  const url = new URL(project.self);
-  return `https://${url.host}/browse/${project.key}`;
+  return `${getJiraBaseUrl(project.self)}/browse/${project.key}`;
 };
 
 /**
  * Get the URL to a issue.
  */
 export const getIssueUrl = (issueUrl: string, issueKey: string) => {
-  const url = new URL(issueUrl);
-  return `https://${url.host}/browse/${issueKey}`;
+  return `${getJiraBaseUrl(issueUrl)}/browse/${issueKey}`;
 };


### PR DESCRIPTION
### Describe your changes

Instead of only using the Jira host when creating project and issue links to Jira, any additional paths are also added. These additional paths are used in Jira Server, and without the path the links are broken.

### Issue ticket number and link

- Fixes #88 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
