### PR TITLE
Change assignee font size

### DIFF
--- a/.changeset/tasty-students-melt.md
+++ b/.changeset/tasty-students-melt.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Changed assignee font size in JiraTable to 14px so it would match the other text in the component.

--- a/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
@@ -92,20 +92,27 @@ export const columns: TableColumn[] = [
                 height: 35,
               }}
             />
-            <Typography>{issue.fields.assignee.displayName}</Typography>
+            <Typography variant="body2">
+              {issue.fields.assignee.displayName}
+            </Typography>
           </Stack>
         );
       } else if (issue.fields?.assignee?.name) {
         return (
-          <Typography>{issue.fields.assignee.name.split('@')[0]}</Typography>
+          <Typography variant="body2">
+            {issue.fields.assignee.name.split('@')[0]}
+          </Typography>
         );
       } else if (issue.fields?.assignee?.key) {
-        return <Typography>{issue.fields.assignee.key}</Typography>;
+        return (
+          <Typography variant="body2">{issue.fields.assignee.key}</Typography>
+        );
       }
       return (
         <Typography
           sx={{ color: theme => theme.palette.text.disabled }}
           color="divider"
+          variant="body2"
         >
           Unassigned
         </Typography>


### PR DESCRIPTION
### Describe your changes

In the JiraTable, the assignee displayname/name/key was 16px while the rest of the text in the table was 14px. This has been fixed by adding variant='body2'. 

### Before:
![Screenshot from 2024-04-08 15-00-23](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/bd019265-ffa9-48c7-a137-0f7b47fab079)

### After:
![Screenshot from 2024-04-08 15-00-14](https://github.com/AxisCommunications/backstage-plugins/assets/76013501/b1ee5679-de4f-4aa2-9fe6-8b28408cee77)




### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation


