### PR TITLE
Enhanced Jira Dashboard plugin to accommodate project key in data fet…

### DIFF
--- a/.changeset/short-buckets-reflect.md
+++ b/.changeset/short-buckets-reflect.md
@@ -1,0 +1,19 @@
+---
+'@axis-backstage/plugin-jira-dashboard': major
+'app': minor
+'backend': minor
+'@axis-backstage/plugin-analytics-module-umami': minor
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-readme': minor
+'@axis-backstage/plugin-readme-backend': minor
+'@axis-backstage/plugin-statuspage': minor
+'@axis-backstage/plugin-statuspage-backend': minor
+'@axis-backstage/plugin-statuspage-common': minor
+---
+
+Implemented project key support for fetching Jira data in the Jira Dashboard plugin.
+Updated the getJiraResponseByEntity method signature in JiraDashboardApi.tsx to include a projectKey parameter.
+Enhanced the JiraDashboardContent.tsx file to extract the project key from entity metadata annotations and pass it to the useJira hook.
+Modified the JiraTable.tsx file to include an optional prop project of type Project to accommodate the project key.
+Updated the useJira.ts file to include the projectKey parameter in the useJira hook signature and pass it to the getJiraResponseByEntity method.

--- a/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
@@ -6,6 +6,9 @@ export const jiraDashboardApiRef = createApiRef<JiraDashboardApi>({
 });
 
 export type JiraDashboardApi = {
-  getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
+  getJiraResponseByEntity(
+    entityRef: string,
+    projectKey: string,
+  ): Promise<JiraResponse>;
   getProjectAvatar(entityRef: string): any;
 };

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -17,17 +17,22 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { jiraDashboardApiRef } from '../../api';
 import { useJira } from '../../hooks/useJira';
-import { JiraDataResponse } from '@axis-backstage/plugin-jira-dashboard-common';
+import {
+  JiraDataResponse,
+  PROJECT_KEY_NAME,
+} from '@axis-backstage/plugin-jira-dashboard-common';
 
 export const JiraDashboardContent = () => {
   const { entity } = useEntity();
+  const projectKey =
+    entity?.metadata.annotations?.[PROJECT_KEY_NAME]?.split(',')[0]!;
   const api = useApi(jiraDashboardApiRef);
 
   const {
     data: jiraResponse,
     loading,
     error,
-  } = useJira(stringifyEntityRef(entity), api);
+  } = useJira(stringifyEntityRef(entity), projectKey, api);
 
   if (loading) {
     return <Progress />;
@@ -37,7 +42,7 @@ export const JiraDashboardContent = () => {
     return (
       <ResponseErrorPanel
         error={Error(
-          'Could not fetch Jira Dashboard content for defined project key',
+          `Could not fetch Jira Dashboard content for project key: ${projectKey}`,
         )}
       />
     );
@@ -70,7 +75,10 @@ export const JiraDashboardContent = () => {
             </Grid>
             {jiraResponse.data.map((value: JiraDataResponse) => (
               <Grid data-testid="issue-table" key={value.name} md={6} xs={12}>
-                <JiraTable tableContent={value} />
+                <JiraTable
+                  tableContent={value}
+                  project={jiraResponse.project}
+                />
               </Grid>
             ))}
           </>

--- a/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
-import { JiraDataResponse } from '@axis-backstage/plugin-jira-dashboard-common';
+import {
+  JiraDataResponse,
+  Project,
+} from '@axis-backstage/plugin-jira-dashboard-common';
 import { ErrorPanel, Table } from '@backstage/core-components';
 import { capitalize } from 'lodash';
 import { columns } from './columns';
 
 type Props = {
   tableContent: JiraDataResponse;
+  project?: Project;
 };
 
 export const JiraTable = ({ tableContent }: Props) => {

--- a/plugins/jira-dashboard/src/hooks/useJira.ts
+++ b/plugins/jira-dashboard/src/hooks/useJira.ts
@@ -4,6 +4,7 @@ import { JiraDashboardApi } from '../api';
 
 export function useJira(
   entityRef: string,
+  projectKey: string,
   jiraDashboardApi: JiraDashboardApi,
 ): {
   data: JiraResponse | undefined;
@@ -15,7 +16,10 @@ export function useJira(
     loading,
     error,
   } = useAsync(async (): Promise<any> => {
-    const response = await jiraDashboardApi.getJiraResponseByEntity(entityRef);
+    const response = await jiraDashboardApi.getJiraResponseByEntity(
+      entityRef,
+      projectKey,
+    );
     response.project.avatarUrls = await jiraDashboardApi.getProjectAvatar(
       entityRef,
     );


### PR DESCRIPTION
Implemented project key support for fetching Jira data in the Jira Dashboard plugin.
Updated the getJiraResponseByEntity method signature in JiraDashboardApi.tsx to include a projectKey parameter.
Enhanced the JiraDashboardContent.tsx file to extract the project key from entity metadata annotations and pass it to the useJira hook.
Modified the JiraTable.tsx file to include an optional prop project of type Project to accommodate the project key.
Updated the useJira.ts file to include the projectKey parameter in the useJira hook signature and pass it to the getJiraResponseByEntity method.

- Fixes #(issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
