### PR TITLE
Log Jira orginal error message.

### DIFF
--- a/.changeset/chilly-deers-agree.md
+++ b/.changeset/chilly-deers-agree.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Enhance error message when querying for projects

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -23,7 +23,9 @@ export const getProjectInfo = async (
     },
   );
   if (response.status !== 200) {
-    throw Error(`${response.status}`);
+    throw Error(
+      `Request failed with status code ${response.status}: ${response.statusText}`,
+    );
   }
   return response.json();
 };

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -141,8 +141,10 @@ export async function createRouter(
           config,
           cache,
         );
-      } catch (err) {
-        logger.error(`Could not find Jira project ${projectKey[0]}`);
+      } catch (err: any) {
+        logger.error(
+          `Could not find Jira project ${projectKey[0]}: ${err.message}`,
+        );
         response.status(404).json({
           error: `No Jira project found with key ${projectKey[0]}`,
         });

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -28,7 +28,9 @@ export const getProjectResponse = async (
     cache.set(projectKey, projectResponse);
   } catch (err: any) {
     if (err.message !== 200) {
-      throw Error(`${err.status}`);
+      throw Error(
+        `Failed to get project info for project key ${projectKey} with error: ${err.message}`,
+      );
     }
   }
   return projectResponse;


### PR DESCRIPTION
When a project cannot be queried from Jira, we currently
swollow the original error message in favour of a general
"Cannot find Jira project"-message. This makes auth-debugging
harder.

- Fixes #121

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
