### PR TITLE
Add annotation for incoming issue status

### DIFF
--- a/.changeset/nasty-ants-dance.md
+++ b/.changeset/nasty-ants-dance.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Created the incoming-issues-annotation to make it possible for users to define Jira status for Incoming issues other than "New". Made some smaller refactoring in filter.ts to create better consistency among functions.

--- a/plugins/jira-dashboard-backend/src/filters.ts
+++ b/plugins/jira-dashboard-backend/src/filters.ts
@@ -15,15 +15,21 @@ const getIncomingFilter = (incomingStatus: string): Filter => ({
   query: `status = ${incomingStatus} ORDER BY created ASC`,
 });
 
-const getUserEmail = (
+const getAssignedToMeFilter = (
   userEntity: UserEntity,
   config: Config,
-): string | undefined => {
+): Filter => {
   const emailSuffixConfig = resolveUserEmailSuffix(config);
 
-  return emailSuffixConfig
+  const email = emailSuffixConfig
     ? `${userEntity.metadata.name}${emailSuffixConfig}`
     : userEntity.spec?.profile?.email;
+
+  return {
+    name: 'Assigned to me',
+    shortName: 'ME',
+    query: `assignee = "${email}" AND resolution = Unresolved ORDER BY updated DESC`,
+  };
 };
 
 export const getDefaultFiltersForUser = (
@@ -35,16 +41,7 @@ export const getDefaultFiltersForUser = (
 
   if (!userEntity) return [openFilter, incomingFilter];
 
-  return [
-    openFilter,
-    incomingFilter,
-    {
-      name: 'Assigned to me',
-      shortName: 'ME',
-      query: `assignee = "${getUserEmail(
-        userEntity,
-        config,
-      )}" AND resolution = Unresolved ORDER BY updated DESC`,
-    },
-  ];
+  const assigneeToMeFilter = getAssignedToMeFilter(userEntity, config);
+
+  return [openFilter, incomingFilter, assigneeToMeFilter];
 };

--- a/plugins/jira-dashboard-backend/src/filters.ts
+++ b/plugins/jira-dashboard-backend/src/filters.ts
@@ -9,11 +9,11 @@ const openFilter: Filter = {
   query: 'resolution = Unresolved ORDER BY updated DESC',
 };
 
-const incomingFilter: Filter = {
+const getIncomingFilter = (incomingStatus: string): Filter => ({
   name: 'Incoming Issues',
   shortName: 'INCOMING',
-  query: 'status = New ORDER BY created ASC',
-};
+  query: `status = ${incomingStatus} ORDER BY created ASC`,
+});
 
 const getUserEmail = (
   userEntity: UserEntity,
@@ -29,7 +29,10 @@ const getUserEmail = (
 export const getDefaultFiltersForUser = (
   config: Config,
   userEntity?: UserEntity,
+  incomingStatus?: string,
 ): Filter[] => {
+  const incomingFilter = getIncomingFilter(incomingStatus ?? 'New');
+
   if (!userEntity) return [openFilter, incomingFilter];
 
   return [

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -3,6 +3,7 @@ import {
   COMPONENTS_NAME,
   PROJECT_KEY_NAME,
   FILTERS_NAME,
+  INCOMING_ISSUES_STATUS,
 } from '@axis-backstage/plugin-jira-dashboard-common';
 import { Config } from '@backstage/config';
 
@@ -12,6 +13,7 @@ export const getAnnotations = (config: Config) => {
   const projectKeyAnnotation = `${prefix}/${PROJECT_KEY_NAME}`;
   const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
   const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
+  const incomingIssuesAnnotation = `${prefix}/${INCOMING_ISSUES_STATUS}`;
 
   /*   Adding support for Roadie's component annotation */
   const componentRoadieAnnotation = `${prefix}/component`;
@@ -19,7 +21,8 @@ export const getAnnotations = (config: Config) => {
   return {
     projectKeyAnnotation,
     componentsAnnotation,
-    componentRoadieAnnotation,
     filtersAnnotation,
+    incomingIssuesAnnotation,
+    componentRoadieAnnotation,
   };
 };

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -113,6 +113,7 @@ export async function createRouter(
         componentsAnnotation,
         componentRoadieAnnotation,
         filtersAnnotation,
+        incomingIssuesAnnotation,
       } = getAnnotations(config);
 
       if (!entity) {
@@ -168,10 +169,13 @@ export async function createRouter(
 
       let filters: Filter[] = [];
 
+      const incomingStatus =
+        entity.metadata.annotations?.[incomingIssuesAnnotation];
+
+      filters = getDefaultFiltersForUser(config, userEntity, incomingStatus);
+
       const customFilterAnnotations =
         entity.metadata.annotations?.[filtersAnnotation]?.split(',')!;
-
-      filters = getDefaultFiltersForUser(config, userEntity);
 
       if (customFilterAnnotations) {
         filters.push(

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -111,9 +111,9 @@ export async function createRouter(
       const {
         projectKeyAnnotation,
         componentsAnnotation,
-        componentRoadieAnnotation,
         filtersAnnotation,
         incomingIssuesAnnotation,
+        componentRoadieAnnotation,
       } = getAnnotations(config);
 
       if (!entity) {

--- a/plugins/jira-dashboard-common/api-report.md
+++ b/plugins/jira-dashboard-common/api-report.md
@@ -17,6 +17,9 @@ export type Filter = {
 export const FILTERS_NAME = 'filter-ids';
 
 // @public
+export const INCOMING_ISSUES_STATUS = 'incoming-issues-status';
+
+// @public
 export type Issue = {
   key: string;
   self: string;

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -16,3 +16,9 @@ export const COMPONENTS_NAME = 'components';
  *  @public
  */
 export const FILTERS_NAME = 'filter-ids';
+
+/**
+ * The annotation name used to provide the name of the status for incoming issues in Jira
+ *  @public
+ */
+export const INCOMING_ISSUES_STATUS = 'incoming-issues-status';

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -18,7 +18,7 @@ export const COMPONENTS_NAME = 'components';
 export const FILTERS_NAME = 'filter-ids';
 
 /**
- * The annotation name used to provide the name of the status for incoming issues in Jira
+ * The annotation name used to provide the status for incoming issues in Jira
  *  @public
  */
 export const INCOMING_ISSUES_STATUS = 'incoming-issues-status';

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -78,7 +78,7 @@ metadata:
 
 If you want to track specific components or filters for your entity, you can add the optional annotations `components` and `filters-ids`. You can specify an endless number of Jira components or filters.
 
-If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status annotation.
+If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status` annotation.
 
 ```yaml
 apiVersion: backstage.io/v1alpha1

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -78,6 +78,8 @@ metadata:
 
 If you want to track specific components or filters for your entity, you can add the optional annotations `components` and `filters-ids`. You can specify an endless number of Jira components or filters.
 
+If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status annotation.
+
 ```yaml
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -87,6 +89,7 @@ metadata:
     jira.com/project-key: value # The key of the Jira project to track for this entity
     jira.com/components: component,component,component # Jira component name separated with a comma. The Roadie Backstage Jira Plugin Jira annotation `/component` is also supported here by default
     jira.com/filter-ids: 12345,67890 # Jira filter id separated with a comma
+    jira.com/incoming-issues-status: Incoming # The name of the status for incoming issues in Jira. Default: New
 ```
 
 ## Layout


### PR DESCRIPTION
### Describe your changes

Previously, the incomingFilter in the Jira Dashboard backend plugin only searched for issues with the status 'New'. However, some projects and organizations do not use this status, but rather 'Incoming'. 

To let teams decide their own incoming status used in the API call to Jira, the optional annotation 'incoming-issues-status' has been added to the Jira Dashboard backend plugin. Status 'New' is still used as default.

Other changes:
- Refactored filter.ts to make both functions return filters and be more consistent.

### Issue ticket number and link

- Fixes #119 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
