### PR TITLE
Fix 500 Cannot set headers after they are sent to the client

### DIFF
--- a/.changeset/purple-nails-peel.md
+++ b/.changeset/purple-nails-peel.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Headers were being set after the response was sent, causing errors. Replaced break statements with return statements in the loop.

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -176,7 +176,7 @@ export async function createRouter(
           response.status(500).json({
             error: `Readme failure: ${error}`,
           });
-          break;
+          return;
         }
       }
     }


### PR DESCRIPTION
### Describe your changes

After Readme backend encountered a 500 status error when attempting to fetch the README file, an error was displayed about the headers could not be set after they had been sent to the client.

This has been fixed by replacing the break statements with return statements within the README_TYPES loop.

### Issue ticket number and link

- Fixes #134 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified that my code follows the style already available in the repository
