### PR TITLE
Fix app workspace dependency

### DIFF
--- a/.changeset/great-insects-raise.md
+++ b/.changeset/great-insects-raise.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Changed plugin-vacation-calendar dependency in app folder to use workspace.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,7 +19,7 @@
     "@axis-backstage/plugin-jira-dashboard-common": "workspace:^",
     "@axis-backstage/plugin-readme": "workspace:^",
     "@axis-backstage/plugin-statuspage": "workspace:^",
-    "@axis-backstage/plugin-vacation-calendar": "^0.2.0",
+    "@axis-backstage/plugin-vacation-calendar": "workspace:^",
     "@backstage-community/plugin-github-actions": "^0.6.16",
     "@backstage/app-defaults": "^1.5.5",
     "@backstage/catalog-model": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,7 +1611,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@axis-backstage/plugin-vacation-calendar@npm:^0.1.0, @axis-backstage/plugin-vacation-calendar@workspace:plugins/vacation-calendar":
+"@axis-backstage/plugin-vacation-calendar@workspace:^, @axis-backstage/plugin-vacation-calendar@workspace:plugins/vacation-calendar":
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-vacation-calendar@workspace:plugins/vacation-calendar"
   dependencies:
@@ -15637,7 +15637,7 @@ __metadata:
     "@axis-backstage/plugin-jira-dashboard-common": "workspace:^"
     "@axis-backstage/plugin-readme": "workspace:^"
     "@axis-backstage/plugin-statuspage": "workspace:^"
-    "@axis-backstage/plugin-vacation-calendar": "npm:^0.1.0"
+    "@axis-backstage/plugin-vacation-calendar": "workspace:^"
     "@backstage-community/plugin-github-actions": "npm:^0.6.16"
     "@backstage/app-defaults": "npm:^1.5.5"
     "@backstage/catalog-model": "npm:^1.5.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The app now uses vacation-calendar plugin workspace dependency instead of 0.2.0. 

### Context

The incorrect dependency in app made the Package Versioning fail during the last merge. This change should fix this issue.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
