### PR TITLE
Generate pluginIds and pluginPackages to all plugins

### DIFF
--- a/.changeset/fluffy-bottles-deliver.md
+++ b/.changeset/fluffy-bottles-deliver.md
@@ -1,0 +1,16 @@
+---
+'@axis-backstage/plugin-analytics-module-umami': minor
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-statuspage-backend': minor
+'@axis-backstage/plugin-statuspage-common': minor
+'@axis-backstage/plugin-vacation-calendar': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+'@axis-backstage/plugin-readme-backend': minor
+'@axis-backstage/plugin-statuspage': minor
+'backend': minor
+'@axis-backstage/plugin-readme': minor
+'app': minor
+---
+
+Generate pluginIds for plugins and bumping @backstage/cli

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/e2e-test-utils": "^0.1.1",
     "@backstage/repo-tools": "^0.9.0",
     "@changesets/cli": "^2.26.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,7 +23,7 @@
     "@backstage-community/plugin-github-actions": "^0.6.16",
     "@backstage/app-defaults": "^1.5.5",
     "@backstage/catalog-model": "^1.5.0",
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/core-app-api": "^1.12.5",
     "@backstage/core-components": "^0.14.7",
     "@backstage/core-plugin-api": "^1.9.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@types/dockerode": "^3.3.0",
     "@types/express": "^4.17.6",
     "@types/express-serve-static-core": "^4.17.5",

--- a/plugins/analytics-module-umami/package.json
+++ b/plugins/analytics-module-umami/package.json
@@ -11,7 +11,11 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "analytics-module-umami",
+    "pluginPackages": [
+      "@axis-backstage/plugin-analytics-module-umami"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -32,7 +36,7 @@
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/dev-utils": "^1.0.32",
     "@backstage/test-utils": "^1.5.5",
     "@testing-library/jest-dom": "6.0.0",

--- a/plugins/jira-dashboard-backend/package.json
+++ b/plugins/jira-dashboard-backend/package.json
@@ -11,7 +11,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "jira-dashboard",
+    "pluginPackages": [
+      "@axis-backstage/plugin-jira-dashboard",
+      "@axis-backstage/plugin-jira-dashboard-backend",
+      "@axis-backstage/plugin-jira-dashboard-common"
+    ]
   },
   "scripts": {
     "start": "backstage-cli package start",
@@ -40,7 +46,7 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^0.3.8",
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@types/supertest": "^2.0.12",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"

--- a/plugins/jira-dashboard-common/package.json
+++ b/plugins/jira-dashboard-common/package.json
@@ -13,7 +13,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "common-library"
+    "role": "common-library",
+    "pluginId": "jira-dashboard",
+    "pluginPackages": [
+      "@axis-backstage/plugin-jira-dashboard",
+      "@axis-backstage/plugin-jira-dashboard-backend",
+      "@axis-backstage/plugin-jira-dashboard-common"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -25,7 +31,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6"
+    "@backstage/cli": "^0.26.10"
   },
   "files": [
     "dist"

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -11,7 +11,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "jira-dashboard",
+    "pluginPackages": [
+      "@axis-backstage/plugin-jira-dashboard",
+      "@axis-backstage/plugin-jira-dashboard-backend",
+      "@axis-backstage/plugin-jira-dashboard-common"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -42,7 +48,7 @@
     "react": "^17.0.0  || ^18.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/core-app-api": "^1.12.5",
     "@backstage/dev-utils": "^1.0.32",
     "@backstage/plugin-catalog-react": "^1.12.0",

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -11,7 +11,12 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "readme",
+    "pluginPackages": [
+      "@axis-backstage/plugin-readme",
+      "@axis-backstage/plugin-readme-backend"
+    ]
   },
   "scripts": {
     "start": "backstage-cli package start",
@@ -38,7 +43,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@types/supertest": "^2.0.12",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"

--- a/plugins/readme/package.json
+++ b/plugins/readme/package.json
@@ -11,7 +11,12 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "readme",
+    "pluginPackages": [
+      "@axis-backstage/plugin-readme",
+      "@axis-backstage/plugin-readme-backend"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -39,7 +44,7 @@
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/core-app-api": "^1.12.5",
     "@backstage/dev-utils": "^1.0.32",
     "@backstage/test-utils": "^1.5.5",

--- a/plugins/statuspage-backend/package.json
+++ b/plugins/statuspage-backend/package.json
@@ -11,7 +11,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "statuspage",
+    "pluginPackages": [
+      "@axis-backstage/plugin-statuspage",
+      "@axis-backstage/plugin-statuspage-backend",
+      "@axis-backstage/plugin-statuspage-common"
+    ]
   },
   "scripts": {
     "start": "backstage-cli package start",
@@ -34,7 +40,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6"
+    "@backstage/cli": "^0.26.10"
   },
   "files": [
     "dist",

--- a/plugins/statuspage-common/package.json
+++ b/plugins/statuspage-common/package.json
@@ -13,7 +13,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "common-library"
+    "role": "common-library",
+    "pluginId": "statuspage",
+    "pluginPackages": [
+      "@axis-backstage/plugin-statuspage",
+      "@axis-backstage/plugin-statuspage-backend",
+      "@axis-backstage/plugin-statuspage-common"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -25,7 +31,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6"
+    "@backstage/cli": "^0.26.10"
   },
   "files": [
     "dist"

--- a/plugins/statuspage/package.json
+++ b/plugins/statuspage/package.json
@@ -11,7 +11,13 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "statuspage",
+    "pluginPackages": [
+      "@axis-backstage/plugin-statuspage",
+      "@axis-backstage/plugin-statuspage-backend",
+      "@axis-backstage/plugin-statuspage-common"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -37,7 +43,7 @@
     "react": "^17.0.0  || ^18.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.6",
+    "@backstage/cli": "^0.26.10",
     "@backstage/dev-utils": "^1.0.32",
     "@testing-library/jest-dom": "^5.10.1"
   },

--- a/plugins/vacation-calendar/package.json
+++ b/plugins/vacation-calendar/package.json
@@ -11,7 +11,11 @@
     "directory": "_release/package"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "vacation-calendar",
+    "pluginPackages": [
+      "@axis-backstage/plugin-vacation-calendar"
+    ]
   },
   "sideEffects": false,
   "scripts": {
@@ -48,7 +52,7 @@
   },
   "devDependencies": {
     "@backstage/catalog-client": "^1.6.5",
-    "@backstage/cli": "^0.26.7",
+    "@backstage/cli": "^0.26.10",
     "@backstage/core-app-api": "^1.12.6",
     "@backstage/dev-utils": "^1.0.33",
     "@backstage/test-utils": "^1.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,7 +1436,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-analytics-module-umami@workspace:plugins/analytics-module-umami"
   dependencies:
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/core-components": "npm:^0.14.7"
     "@backstage/core-plugin-api": "npm:^1.9.2"
@@ -1460,7 +1460,7 @@ __metadata:
     "@backstage/backend-test-utils": "npm:^0.3.8"
     "@backstage/catalog-client": "npm:^1.6.5"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/plugin-auth-node": "npm:^0.4.13"
     "@backstage/plugin-permission-common": "npm:^0.7.13"
@@ -1480,7 +1480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-jira-dashboard-common@workspace:plugins/jira-dashboard-common"
   dependencies:
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
   languageName: unknown
   linkType: soft
 
@@ -1490,7 +1490,7 @@ __metadata:
   dependencies:
     "@axis-backstage/plugin-jira-dashboard-common": "workspace:^"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/core-app-api": "npm:^1.12.5"
     "@backstage/core-components": "npm:^0.14.7"
     "@backstage/core-plugin-api": "npm:^1.9.2"
@@ -1523,7 +1523,7 @@ __metadata:
     "@backstage/backend-plugin-api": "npm:^0.6.18"
     "@backstage/catalog-client": "npm:^1.6.5"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/integration": "npm:^1.11.0"
     "@backstage/plugin-permission-common": "npm:^0.7.13"
@@ -1544,7 +1544,7 @@ __metadata:
   resolution: "@axis-backstage/plugin-readme@workspace:plugins/readme"
   dependencies:
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/core-app-api": "npm:^1.12.5"
     "@backstage/core-components": "npm:^0.14.7"
     "@backstage/core-plugin-api": "npm:^1.9.2"
@@ -1573,7 +1573,7 @@ __metadata:
     "@axis-backstage/plugin-statuspage-common": "workspace:^"
     "@backstage/backend-common": "npm:^0.22.0"
     "@backstage/backend-plugin-api": "npm:^0.6.18"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/config": "npm:^1.2.0"
     "@types/express": "npm:*"
     cross-fetch: "npm:^4.0.0"
@@ -1587,7 +1587,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-statuspage-common@workspace:plugins/statuspage-common"
   dependencies:
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
   languageName: unknown
   linkType: soft
 
@@ -1597,7 +1597,7 @@ __metadata:
   dependencies:
     "@axis-backstage/plugin-statuspage-common": "workspace:^"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/core-components": "npm:^0.14.7"
     "@backstage/core-plugin-api": "npm:^1.9.2"
     "@backstage/dev-utils": "npm:^1.0.32"
@@ -1617,7 +1617,7 @@ __metadata:
   dependencies:
     "@backstage/catalog-client": "npm:^1.6.5"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.7"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/core-app-api": "npm:^1.12.6"
     "@backstage/core-components": "npm:^0.14.8"
     "@backstage/core-plugin-api": "npm:^1.9.3"
@@ -3683,144 +3683,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.26.6":
-  version: 0.26.6
-  resolution: "@backstage/cli@npm:0.26.6"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli-common": "npm:^0.1.13"
-    "@backstage/cli-node": "npm:^0.2.5"
-    "@backstage/config": "npm:^1.2.0"
-    "@backstage/config-loader": "npm:^1.8.0"
-    "@backstage/errors": "npm:^1.2.4"
-    "@backstage/eslint-plugin": "npm:^0.1.8"
-    "@backstage/integration": "npm:^1.11.0"
-    "@backstage/release-manifests": "npm:^0.0.11"
-    "@backstage/types": "npm:^1.1.1"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@octokit/graphql": "npm:^5.0.0"
-    "@octokit/graphql-schema": "npm:^13.7.0"
-    "@octokit/oauth-app": "npm:^4.2.0"
-    "@octokit/request": "npm:^6.0.0"
-    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.7"
-    "@rollup/plugin-commonjs": "npm:^25.0.0"
-    "@rollup/plugin-json": "npm:^6.0.0"
-    "@rollup/plugin-node-resolve": "npm:^15.0.0"
-    "@rollup/plugin-yaml": "npm:^4.0.0"
-    "@spotify/eslint-config-base": "npm:^15.0.0"
-    "@spotify/eslint-config-react": "npm:^15.0.0"
-    "@spotify/eslint-config-typescript": "npm:^15.0.0"
-    "@sucrase/webpack-loader": "npm:^2.0.0"
-    "@svgr/core": "npm:6.5.x"
-    "@svgr/plugin-jsx": "npm:6.5.x"
-    "@svgr/plugin-svgo": "npm:6.5.x"
-    "@svgr/rollup": "npm:6.5.x"
-    "@svgr/webpack": "npm:6.5.x"
-    "@swc/core": "npm:^1.3.46"
-    "@swc/helpers": "npm:^0.5.0"
-    "@swc/jest": "npm:^0.2.22"
-    "@types/jest": "npm:^29.5.11"
-    "@types/webpack-env": "npm:^1.15.2"
-    "@typescript-eslint/eslint-plugin": "npm:^6.12.0"
-    "@typescript-eslint/parser": "npm:^6.7.2"
-    "@yarnpkg/lockfile": "npm:^1.1.0"
-    "@yarnpkg/parsers": "npm:^3.0.0-rc.4"
-    bfj: "npm:^8.0.0"
-    buffer: "npm:^6.0.3"
-    chalk: "npm:^4.0.0"
-    chokidar: "npm:^3.3.1"
-    commander: "npm:^12.0.0"
-    cross-fetch: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.3"
-    css-loader: "npm:^6.5.1"
-    ctrlc-windows: "npm:^2.1.0"
-    diff: "npm:^5.0.0"
-    esbuild: "npm:^0.20.0"
-    esbuild-loader: "npm:^4.0.0"
-    eslint: "npm:^8.6.0"
-    eslint-config-prettier: "npm:^9.0.0"
-    eslint-formatter-friendly: "npm:^7.0.0"
-    eslint-plugin-deprecation: "npm:^2.0.0"
-    eslint-plugin-import: "npm:^2.25.4"
-    eslint-plugin-jest: "npm:^27.0.0"
-    eslint-plugin-jsx-a11y: "npm:^6.5.1"
-    eslint-plugin-react: "npm:^7.28.0"
-    eslint-plugin-react-hooks: "npm:^4.3.0"
-    eslint-plugin-unused-imports: "npm:^3.0.0"
-    eslint-webpack-plugin: "npm:^4.0.0"
-    express: "npm:^4.17.1"
-    fork-ts-checker-webpack-plugin: "npm:^9.0.0"
-    fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^14.0.0"
-    glob: "npm:^7.1.7"
-    global-agent: "npm:^3.0.0"
-    handlebars: "npm:^4.7.3"
-    html-webpack-plugin: "npm:^5.3.1"
-    inquirer: "npm:^8.2.0"
-    jest: "npm:^29.7.0"
-    jest-css-modules: "npm:^2.1.0"
-    jest-environment-jsdom: "npm:^29.0.2"
-    jest-runtime: "npm:^29.0.2"
-    json-schema: "npm:^0.4.0"
-    lodash: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^2.4.2"
-    minimatch: "npm:^9.0.0"
-    node-fetch: "npm:^2.6.7"
-    node-libs-browser: "npm:^2.2.1"
-    npm-packlist: "npm:^5.0.0"
-    ora: "npm:^5.3.0"
-    p-limit: "npm:^3.1.0"
-    p-queue: "npm:^6.6.2"
-    pirates: "npm:^4.0.6"
-    postcss: "npm:^8.1.0"
-    process: "npm:^0.11.10"
-    react-dev-utils: "npm:^12.0.0-next.60"
-    react-refresh: "npm:^0.14.0"
-    recursive-readdir: "npm:^2.2.2"
-    replace-in-file: "npm:^7.1.0"
-    rollup: "npm:^4.0.0"
-    rollup-plugin-dts: "npm:^6.1.0"
-    rollup-plugin-esbuild: "npm:^6.1.1"
-    rollup-plugin-postcss: "npm:^4.0.0"
-    rollup-pluginutils: "npm:^2.8.2"
-    run-script-webpack-plugin: "npm:^0.2.0"
-    semver: "npm:^7.5.3"
-    style-loader: "npm:^3.3.1"
-    sucrase: "npm:^3.20.2"
-    swc-loader: "npm:^0.2.3"
-    tar: "npm:^6.1.12"
-    terser-webpack-plugin: "npm:^5.1.3"
-    util: "npm:^0.12.3"
-    webpack: "npm:^5.70.0"
-    webpack-dev-server: "npm:^5.0.0"
-    webpack-node-externals: "npm:^3.0.0"
-    yaml: "npm:^2.0.0"
-    yml-loader: "npm:^2.1.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.22.4"
-  peerDependencies:
-    "@vitejs/plugin-react": ^4.0.4
-    vite: ^4.4.9
-    vite-plugin-html: ^3.2.0
-    vite-plugin-node-polyfills: ^0.21.0
-  peerDependenciesMeta:
-    "@vitejs/plugin-react":
-      optional: true
-    vite:
-      optional: true
-    vite-plugin-html:
-      optional: true
-    vite-plugin-node-polyfills:
-      optional: true
-  bin:
-    backstage-cli: bin/backstage-cli
-  checksum: 2ee239d85695aa8aa824d39103ee671d1c87e70c7f921f42c43fd989f0fbd0ee414f57cb53810b949da0037f34337e08db0ced0eacd83084f4ba9c47371a1d96
-  languageName: node
-  linkType: hard
-
-"@backstage/cli@npm:^0.26.7":
-  version: 0.26.9
-  resolution: "@backstage/cli@npm:0.26.9"
+"@backstage/cli@npm:^0.26.10":
+  version: 0.26.10
+  resolution: "@backstage/cli@npm:0.26.10"
   dependencies:
     "@backstage/catalog-model": "npm:^1.5.0"
     "@backstage/cli-common": "npm:^0.1.14"
@@ -3949,7 +3814,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 39af840363e6a13577172315a3555777b7825a8b96987506e317a38473c29bd6df828488476ca8cdbdd2743166b9f29c5bc7ca5d2ee14dcc270509791effdda8
+  checksum: 1c689c6c3c5176dc1337d4b991ed1e00318907bb5d9c2378cf64717be680ade3a7c7d664b78fa3e5c5d10401188e62671069e395cc9a68971323edaeed3dec38
   languageName: node
   linkType: hard
 
@@ -15641,7 +15506,7 @@ __metadata:
     "@backstage-community/plugin-github-actions": "npm:^0.6.16"
     "@backstage/app-defaults": "npm:^1.5.5"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/core-app-api": "npm:^1.12.5"
     "@backstage/core-components": "npm:^0.14.7"
     "@backstage/core-plugin-api": "npm:^1.9.2"
@@ -16381,7 +16246,7 @@ __metadata:
     "@backstage/backend-tasks": "npm:^0.5.23"
     "@backstage/catalog-client": "npm:^1.6.5"
     "@backstage/catalog-model": "npm:^1.5.0"
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/config": "npm:^1.2.0"
     "@backstage/plugin-app-backend": "npm:^0.3.67"
     "@backstage/plugin-auth-backend": "npm:^0.22.5"
@@ -32112,7 +31977,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
-    "@backstage/cli": "npm:^0.26.6"
+    "@backstage/cli": "npm:^0.26.10"
     "@backstage/e2e-test-utils": "npm:^0.1.1"
     "@backstage/repo-tools": "npm:^0.9.0"
     "@changesets/cli": "npm:^2.26.2"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changes:

- Generated pluginIds and pluginPackages to all plugins by running ```backstage-cli repo fix --publish```
- Had to bump @backstage/cli to 0.26.10

### Context

Previous error when merging Package versioning stated: ```Error: Plugin package @axis-backstage/plugin-vacation-calendar is missing a backstage.pluginId, please run 'backstage-cli repo fix --publish' ```

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
