### PR TITLE
chore(statusPage): fix circular dependency

### DIFF
--- a/.changeset/hot-ears-press.md
+++ b/.changeset/hot-ears-press.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-statuspage': patch
+---
+
+Fix circular dependencies

--- a/plugins/statuspage/src/components/StatusChip.tsx
+++ b/plugins/statuspage/src/components/StatusChip.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
-import type { ComponentStatus } from '@axis-backstage/plugin-statuspage-common';
 import Chip from '@mui/material/Chip';
-import { statusColorMap } from './StatuspageComponent';
+import type { ComponentStatus } from '@axis-backstage/plugin-statuspage-common';
+
+/**
+ * Maps statuspage component statuses to MUI colors.
+ *
+ */
+const statusColorMap: { [key in ComponentStatus]: string } = {
+  under_maintenance: 'info',
+  operational: 'success',
+  degraded_performance: 'warning',
+  partial_outage: 'warning',
+  major_outage: 'error',
+};
 
 type StatusChipProps = {
   status: ComponentStatus;

--- a/plugins/statuspage/src/components/StatuspageComponent.tsx
+++ b/plugins/statuspage/src/components/StatuspageComponent.tsx
@@ -4,7 +4,6 @@ import {
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';
-import type { ComponentStatus } from '@axis-backstage/plugin-statuspage-common';
 import { ComponentGroupsList } from './ComponentGroupsList';
 import IconButton from '@mui/material/IconButton';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -17,19 +16,6 @@ import { useComponents } from '../hooks/useComponents';
  */
 export type StatuspageProps = {
   name: string;
-};
-
-/**
- * Maps statuspage component statuses to MUI colors.
- *
- * @public
- */
-export const statusColorMap: { [key in ComponentStatus]: string } = {
-  under_maintenance: 'info',
-  operational: 'success',
-  degraded_performance: 'warning',
-  partial_outage: 'warning',
-  major_outage: 'error',
 };
 
 /**


### PR DESCRIPTION
Moved the "statusColorMap" to the file where it is used to avoid a circular dependency chain.

