### PR TITLE
Add moment dependency to vacation-calendar plugin

### DIFF
--- a/.changeset/healthy-rice-travel.md
+++ b/.changeset/healthy-rice-travel.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-vacation-calendar': patch
+---
+
+Add moment to dependecies in vacation-calendar package.json to resolve 'Can't resolve 'moment' in .../node_modules/react-calendar-timeline/lib/lib/items'

--- a/plugins/vacation-calendar/package.json
+++ b/plugins/vacation-calendar/package.json
@@ -40,6 +40,7 @@
     "interactjs": "^1.10.27",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",
+    "moment": "^2.30.1",
     "react-calendar-timeline": "^0.28.0",
     "react-use": "^17.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,6 +1642,7 @@ __metadata:
     interactjs: "npm:^1.10.27"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.4.4"
+    moment: "npm:^2.30.1"
     react-calendar-timeline: "npm:^0.28.0"
     react-use: "npm:^17.5.0"
   peerDependencies:
@@ -27318,7 +27319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.0.0":
+"moment@npm:^2.0.0, moment@npm:^2.30.1":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Dependency `moment` has been added to the package.json of the vacation-calendar plugin. 
 
### Context

`moment` is a peer dependency to `react-calendar-timeline`, and without it the following error is displayed in any repo that is trying to install axis-backstage/vacation-calendar-plugin: ```Module not found: Can't resolve 'moment' in '/axis-backstage/node_modules/react-calendar-timeline/lib/lib/items'
node_modules/react-calendar-timeline/lib/lib/items/Item.js```. Adding the dependency should fix this error.

### Checklist before requesting a review

- [ x I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
