### PR TITLE
update docs after upgrading to 1.30 & add react-dom peer dependency

### DIFF
--- a/.changeset/red-eyes-exercise.md
+++ b/.changeset/red-eyes-exercise.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Add react-dom as a peer-dependency

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -146,13 +146,11 @@ import jiraPlugin from '@axis-backstage/plugin-jira-dashboard/alpha';
 const jiraAnnotationExtension = createExtension({
   name: 'myJiraAnnotation',
   attachTo: { id: 'entity-content:jira-dashboard/entity', input: 'props' },
-  output: {
-    annotationPrefix: annotationPrefixExtensionDataRef,
-  },
+  output: [annotationPrefixExtensionDataRef],
 
   factory() {
     // This can be any value you want to check for
-    return { annotationPrefix: 'jira' };
+    return [ annotationPrefixExtensionDataRef('jira') ];
   },
 });
 const app = createApp({

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -60,7 +60,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "react": "^17.0.0  || ^18.0.0"
+    "react": "^17.0.0  || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,6 +1514,7 @@ __metadata:
     "@emotion/react": ^11.11.3
     "@emotion/styled": ^11.11.0
     react: ^17.0.0  || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Apologies - Missed one section in the docs that should've been updated in https://github.com/AxisCommunications/backstage-plugins/pull/164 ! Should be merged before the [version packages](https://github.com/AxisCommunications/backstage-plugins/pull/165) are cut.

This change also includes react-dom as a peer-dependency. Jira-dashboard depends on @backstage/core-components, which itself has a [peerDependency](https://github.com/backstage/backstage/blob/master/packages/core-components/package.json#L122) on react-dom; so we need to either fulfill that dependency or declare it a peerDependency of our own!

### Context

Please provide some context about the why this change is being made and what problem it aims to solve.

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- x ] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
