### PR TITLE
Add more peer dependencies

### DIFF
--- a/.changeset/long-penguins-hammer.md
+++ b/.changeset/long-penguins-hammer.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Add peer dependencies (react-router-dom, material-ui/core, types/react)

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -60,8 +60,11 @@
   "peerDependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@material-ui/core": "^4.12.2",
+    "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0  || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,8 +1513,11 @@ __metadata:
   peerDependencies:
     "@emotion/react": ^11.11.3
     "@emotion/styled": ^11.11.0
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0  || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Jira-dashboard newly depends on @backstage/theme, which itself has [peerDependencies](https://github.com/backstage/backstage/blob/v1.30.1/packages/theme/package.json#L51-L52); so we need to either fulfill that dependency or declare it a peerDependency of our own! Core-compat-api also had an unfulfilled peer dep on [react-router-dom](https://github.com/backstage/backstage/blob/v1.30.1/packages/core-compat-api/package.json#L55), so adding that as well.

### Context

Please provide some context about the why this change is being made and what problem it aims to solve.

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
