### PR TITLE
fix: Fix rendering discovered since 1.3.0

### DIFF
--- a/.changeset/eleven-plums-beam.md
+++ b/.changeset/eleven-plums-beam.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+fix rendering discovered since 1.3.0

--- a/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/columns.tsx
@@ -68,7 +68,7 @@ export const columns: TableColumn[] = [
           to={getIssueUrl(issue.self, issue.key)}
           title="Go to issue in Jira"
         >
-          {issue.fields?.priority.name}
+          {issue.fields?.priority?.name}
         </Link>
       );
     },

--- a/plugins/jira-dashboard/src/components/JiraTable/mockedJiraDataResponse.json
+++ b/plugins/jira-dashboard/src/components/JiraTable/mockedJiraDataResponse.json
@@ -64,6 +64,24 @@
           "name": "Major"
         }
       }
+    },
+    {
+      "key": "BS-4",
+      "self": "https://jira.com/project/123",
+      "fields": {
+        "summary": "Quick fix on frontend",
+        "status": {
+          "name": "Open"
+        },
+        "assignee": {
+          "name": "fridaja@backstage",
+          "self": "https://jira.com/user/fridaja"
+        },
+        "issuetype": {
+          "name": "Bug",
+          "iconUrl": ""
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix rendering discovered since 1.3.0

### Context

When a priority field  is missing on an issue, I got this

![image (4)](https://github.com/user-attachments/assets/8f5bdd04-fafd-4fd3-ae11-f08029f04811)
![image (5)](https://github.com/user-attachments/assets/883ae4a5-fd9d-48b5-a685-eb61b0f125ae)
![image (3)](https://github.com/user-attachments/assets/52fbc22e-63c9-4ae4-9a03-d9949ecd6064)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
