### PR TITLE
fix(jira-dashboard): Fix release issues

### DIFF
--- a/.changeset/proud-chairs-lie.md
+++ b/.changeset/proud-chairs-lie.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Fix CI release issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 21.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 21.x
 
       - name: Install Dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "21"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",


### PR DESCRIPTION
When the new frontend support was added, the introduced exports-
field in jira-dashboards package.json breaks for Node <21.

Let's just use Node 21.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
