### PR TITLE
Add JiraUserIssuesViewCard to Homepage

### DIFF
--- a/.changeset/blue-pandas-pretend.md
+++ b/.changeset/blue-pandas-pretend.md
@@ -1,0 +1,5 @@
+---
+'app': minor
+---
+
+Added the JiraUserIssuesViewCard component to the Homepage

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -9,6 +9,7 @@ import { Content, Header, Page } from '@backstage/core-components';
 import React from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
 import { SearchBar } from '@backstage/plugin-search-react';
+import { JiraUserIssuesViewCard } from '@axis-backstage/plugin-jira-dashboard';
 
 export const homePage = (
   <Page themeId="home">
@@ -32,6 +33,14 @@ export const homePage = (
         <Grid container xs={7}>
           <Grid xs={12}>
             <HomePageRandomJoke />
+          </Grid>
+          <Grid xs={12}>
+            <JiraUserIssuesViewCard
+              bottomLinkProps={{
+                link: 'https://our-jira-server/issues',
+                title: 'Open in Jira',
+              }}
+            />
           </Grid>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I’ve added the JiraUserIssuesViewCard from the Jira Dashboard plugin to the app's Homepage.

### Context

Adding the JiraUserIssuesViewCard to the Homepage provides a example of how the plugin looks and functions, making it easier for plugin adapters to see its behavior in action..

### Screenshots

![Screenshot from 2024-09-06 11-24-07](https://github.com/user-attachments/assets/06e6bb11-3b45-47ec-a173-4ae2c4c93384)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Screenshots attached (for UI changes)
