### PR TITLE
fix: escape incoming status string

### DIFF
--- a/.changeset/thirty-bulldogs-design.md
+++ b/.changeset/thirty-bulldogs-design.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Quote the incoming status string in the JQL. This makes it possible to have strings that contain whitespace.

--- a/plugins/jira-dashboard-backend/src/filters.ts
+++ b/plugins/jira-dashboard-backend/src/filters.ts
@@ -12,7 +12,7 @@ const openFilter: Filter = {
 const getIncomingFilter = (incomingStatus: string): Filter => ({
   name: 'Incoming Issues',
   shortName: 'INCOMING',
-  query: `status = ${incomingStatus} ORDER BY created ASC`,
+  query: `status = '${incomingStatus}' ORDER BY created ASC`,
 });
 
 /**


### PR DESCRIPTION
there could be white space here (like in the components) so it must included in qoutes.

fixes #179
