### PR TITLE
fix(readme-backend): remove the tokenmanager from the plugin deps

### DIFF
--- a/.changeset/sharp-planes-listen.md
+++ b/.changeset/sharp-planes-listen.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Removed the tokenmanager as dependency for new backend system plugin definition.

--- a/plugins/readme-backend/api-report.md
+++ b/plugins/readme-backend/api-report.md
@@ -26,6 +26,6 @@ export interface RouterOptions {
   discovery: DiscoveryService;
   logger: LoggerService;
   reader: UrlReaderService;
-  tokenManager: TokenManagerService;
+  tokenManager?: TokenManagerService;
 }
 ```

--- a/plugins/readme-backend/src/plugin.ts
+++ b/plugins/readme-backend/src/plugin.ts
@@ -19,18 +19,9 @@ export const readmePlugin = createBackendPlugin({
         reader: coreServices.urlReader,
         discovery: coreServices.discovery,
         auth: coreServices.auth,
-        tokenManager: coreServices.tokenManager,
         httpRouter: coreServices.httpRouter,
       },
-      async init({
-        auth,
-        logger,
-        config,
-        reader,
-        discovery,
-        tokenManager,
-        httpRouter,
-      }) {
+      async init({ auth, logger, config, reader, discovery, httpRouter }) {
         httpRouter.use(
           await createRouter({
             auth,
@@ -38,7 +29,6 @@ export const readmePlugin = createBackendPlugin({
             config,
             reader,
             discovery,
-            tokenManager,
           }),
         );
       },

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -45,7 +45,7 @@ export interface RouterOptions {
   /**
    * Backstage token manager service
    */
-  tokenManager: TokenManagerService;
+  tokenManager?: TokenManagerService;
   /**
    * Backstage auth service
    */


### PR DESCRIPTION
The "tokenmanager" have been removed from the "coreServices", making the plugin impossible to use
with the current next release of backstage.

### Context

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X ] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
