### PR TITLE
Chore: Deprecated 'createRouter' and 'RouterOptions' exports

### DIFF
--- a/.changeset/selfish-kids-check.md
+++ b/.changeset/selfish-kids-check.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+'@axis-backstage/plugin-statuspage-backend': patch
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Marked `createRouter` and `RouterOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -15,7 +15,7 @@ import { RootConfigService } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { UserInfoService } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
@@ -36,7 +36,7 @@ export type JqlQueryBuilderArgs = {
   query?: string;
 };
 
-// @public
+// @public @deprecated
 export interface RouterOptions {
   auth?: AuthService;
   config: RootConfigService;

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -35,6 +35,7 @@ import { getAnnotations } from '../lib';
 
 /**
  * Constructs a jira dashboard router.
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export interface RouterOptions {
@@ -84,6 +85,7 @@ const DEFAULT_MAX_RESULTS_USER_ISSUES = 10;
 /**
  * Constructs a jira dashboard router.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export async function createRouter(

--- a/plugins/readme-backend/api-report.md
+++ b/plugins/readme-backend/api-report.md
@@ -12,14 +12,14 @@ import { RootConfigService } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
 const readmePlugin: BackendFeatureCompat;
 export default readmePlugin;
 
-// @public
+// @public @deprecated
 export interface RouterOptions {
   auth?: AuthService;
   config: RootConfigService;

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -21,6 +21,7 @@ import { isSymLink } from '../lib';
 
 /**
  * Constructs a readme router.
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export interface RouterOptions {
@@ -73,6 +74,7 @@ const README_TYPES: FileType[] = [
 /**
  * Constructs a readme router.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export async function createRouter(

--- a/plugins/statuspage-backend/api-report.md
+++ b/plugins/statuspage-backend/api-report.md
@@ -8,10 +8,10 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public
+// @public @deprecated
 export interface RouterOptions {
   config: Config;
   logger: LoggerService;

--- a/plugins/statuspage-backend/src/service/router.ts
+++ b/plugins/statuspage-backend/src/service/router.ts
@@ -9,6 +9,7 @@ import { getStatuspageConfig } from '../config';
 /**
  * Router options.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export interface RouterOptions {
@@ -24,6 +25,7 @@ const COMPONENTS_KEY = 'components';
 /**
  * Create the router.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export async function createRouter(


### PR DESCRIPTION
These exports is only useful for the old backend system. Support for the old backend system will soon be removed from "upstreams" plugins.

