### PR TITLE
Hide ReadmeCard if backend returns 404

### DIFF
--- a/.changeset/kind-avocados-smell.md
+++ b/.changeset/kind-avocados-smell.md
@@ -1,6 +1,7 @@
 ---
+'@axis-backstage/plugin-readme-backend': minor
 '@axis-backstage/plugin-readme': minor
 'app': minor
 ---
 
-Created a new function in the Readme-plugin that return false if no README content is found due to 404-error. If function returns false, no ReadmeCard is rendered in EntityPage.
+Created the isReadmeAvailable function that returns false if no README content is found due to 404-error. If it returns false, no ReadmeCard is rendered in EntityPage. Also updated the error response from backend to be a NotFoundError.

--- a/.changeset/kind-avocados-smell.md
+++ b/.changeset/kind-avocados-smell.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-readme': minor
+'app': minor
+---
+
+Created a new function in the Readme-plugin that return false if no README content is found due to 404-error. If function returns false, no ReadmeCard is rendered in EntityPage.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -56,7 +56,7 @@ import {
   EntityJiraDashboardContent,
   isJiraDashboardAvailable,
 } from '@axis-backstage/plugin-jira-dashboard';
-import { ReadmeCard } from '@axis-backstage/plugin-readme';
+import { ReadmeCard, isReadmeAvailable } from '@axis-backstage/plugin-readme';
 import {
   isStatuspageAvailable,
   StatuspageEntityCard,
@@ -115,9 +115,13 @@ const overviewContent = (
     <Grid md={6} xs={12}>
       <EntityLinksCard />
     </Grid>
-    <Grid md={6} xs={12}>
-      <ReadmeCard />
-    </Grid>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isReadmeAvailable}>
+        <Grid md={6} xs={12}>
+          <ReadmeCard maxHeight={350} />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
     <Grid md={6} xs={12}>
       <EntityCatalogGraphCard height={400} />
     </Grid>

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -33,6 +33,7 @@
     "@backstage/backend-plugin-api": "^0.8.0",
     "@backstage/catalog-client": "^1.6.6",
     "@backstage/catalog-model": "^1.6.0",
+    "@backstage/errors": "^1.2.4",
     "@backstage/integration": "^1.14.0",
     "@types/express": "*",
     "express": "^4.17.1",

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -48,6 +48,24 @@ const overviewContent = (
 )
 ```
 
+If you wish to only render the ReadmeCard if a README file can be found for the entity, you can use the exported function **isReadmeAvailable**. See example below:
+
+```tsx
+import { ReadmeCard, isReadmeAvailable } from '@axis-backstage/plugin-readme';
+
+const defaultEntityPage = (
+...
+     <EntitySwitch>
+      <EntitySwitch.Case if={isReadmeAvailable}>
+        <Grid md={6} xs={12}>
+          <ReadmeCard maxHeight={350} />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+...
+)
+```
+
 To use `ReadmeCard` in a seperate page with full height:
 
 ```tsx
@@ -59,6 +77,7 @@ const defaultEntityPage = (
       <ReadmeCard variant="fullHeight" />
     </EntityLayout.Route>
 ...
+)
 ```
 
 ## Layout

--- a/plugins/readme/api-report.md
+++ b/plugins/readme/api-report.md
@@ -5,10 +5,20 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiHolder } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
 import { InfoCardVariants } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
+
+// @public
+export const isReadmeAvailable: (
+  entity: Entity,
+  context: {
+    apis: ApiHolder;
+  },
+) => Promise<boolean>;
 
 // @public
 export const ReadmeCard: (props: ReadmeCardProps) => JSX_2.Element;

--- a/plugins/readme/package.json
+++ b/plugins/readme/package.json
@@ -32,6 +32,7 @@
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/core-components": "^0.14.10",
     "@backstage/core-plugin-api": "^1.9.3",
+    "@backstage/errors": "^1.2.4",
     "@backstage/plugin-catalog-react": "^1.12.3",
     "@backstage/theme": "^0.5.6",
     "@mui/icons-material": "^5.15.7",

--- a/plugins/readme/src/api/ReadmeClient.tsx
+++ b/plugins/readme/src/api/ReadmeClient.tsx
@@ -79,9 +79,6 @@ export class ReadmeClient implements ReadmeApi {
       ];
     }
 
-    if (resp.status === 404) {
-      throw await ResponseError.fromResponse(resp);
-    }
-    throw new Error(`${resp.status}: ${resp.statusText}`);
+    throw await ResponseError.fromResponse(resp);
   }
 }

--- a/plugins/readme/src/api/ReadmeClient.tsx
+++ b/plugins/readme/src/api/ReadmeClient.tsx
@@ -13,6 +13,14 @@ import {
 import { NotFoundError } from '@backstage/errors';
 import { ReadmeApi, readmeApiRef } from './ReadmeApi';
 
+/**
+ * Checks if a README is available for the given entity by making a request to the backend.
+If the backend returns a 404 NotFound error, it indicates that no README is available for the entity.
+@param entity - The entity for which to check the README availability.
+@param context - The context providing access to the API holder.
+@returns A promise that resolves to true if the README is available, or false if not found (404).
+ *  @public
+ */
 export const isReadmeAvailable = async (
   entity: Entity,
   context: { apis: ApiHolder },

--- a/plugins/readme/src/api/ReadmeClient.tsx
+++ b/plugins/readme/src/api/ReadmeClient.tsx
@@ -10,7 +10,7 @@ import {
   parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { NotFoundError } from '@backstage/errors';
+import { NotFoundError, ResponseError } from '@backstage/errors';
 import { ReadmeApi, readmeApiRef } from './ReadmeApi';
 
 /**
@@ -34,7 +34,7 @@ export const isReadmeAvailable = async (
   try {
     await readmeClient.getReadmeContent(stringifyEntityRef(entity));
   } catch (error) {
-    if (error instanceof NotFoundError) {
+    if (error instanceof ResponseError && error.statusCode === 404) {
       return false;
     }
   }
@@ -80,7 +80,7 @@ export class ReadmeClient implements ReadmeApi {
     }
 
     if (resp.status === 404) {
-      throw new NotFoundError();
+      throw await ResponseError.fromResponse(resp);
     }
     throw new Error(`${resp.status}: ${resp.statusText}`);
   }

--- a/plugins/readme/src/api/ReadmeClient.tsx
+++ b/plugins/readme/src/api/ReadmeClient.tsx
@@ -10,7 +10,7 @@ import {
   parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { NotFoundError, ResponseError } from '@backstage/errors';
+import { ResponseError } from '@backstage/errors';
 import { ReadmeApi, readmeApiRef } from './ReadmeApi';
 
 /**

--- a/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
+++ b/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
@@ -41,7 +41,6 @@ export const FetchComponent = () => {
   if (loading) {
     return <Progress />;
   }
-  console.log(error);
 
   if (error instanceof ResponseError && error.statusCode === 404) {
     return (

--- a/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
+++ b/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
@@ -7,6 +7,7 @@ import {
   Link,
   MarkdownContent,
   Progress,
+  ResponseErrorPanel,
 } from '@backstage/core-components';
 import useAsync from 'react-use/lib/useAsync';
 import { readmeApiRef } from '../../api/ReadmeApi';
@@ -42,21 +43,24 @@ export const FetchComponent = () => {
     return <Progress />;
   }
 
-  if (error instanceof ResponseError && error.statusCode === 404) {
-    return (
-      <Box>
-        <Typography pb={2} variant="body2">
-          No README.md file found at source location:{' '}
-          {location && <strong>{location}</strong>}
-        </Typography>
-        <Typography variant="body2">
-          Need help? Go to our{' '}
-          <Link to="https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/README.md">
-            documentation
-          </Link>
-        </Typography>
-      </Box>
-    );
+  if (error instanceof ResponseError) {
+    if (error.statusCode === 404) {
+      return (
+        <Box>
+          <Typography pb={2} variant="body2">
+            No README.md file found at source location:{' '}
+            {location && <strong>{location}</strong>}
+          </Typography>
+          <Typography variant="body2">
+            Need help? Go to our{' '}
+            <Link to="https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/readme/README.md">
+              documentation
+            </Link>
+          </Typography>
+        </Box>
+      );
+    }
+    return <ResponseErrorPanel error={error} />;
   }
 
   if (error) {

--- a/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
+++ b/plugins/readme/src/components/FetchComponent/FetchComponent.tsx
@@ -14,6 +14,7 @@ import { stringifyEntityRef } from '@backstage/catalog-model';
 import { getEntitySourceLocation } from '@backstage/catalog-model';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { ResponseError } from '@backstage/errors';
 
 export const FetchComponent = () => {
   const { entity } = useEntity();
@@ -40,7 +41,9 @@ export const FetchComponent = () => {
   if (loading) {
     return <Progress />;
   }
-  if (error?.message === '404') {
+  console.log(error);
+
+  if (error instanceof ResponseError && error.statusCode === 404) {
     return (
       <Box>
         <Typography pb={2} variant="body2">

--- a/plugins/readme/src/index.ts
+++ b/plugins/readme/src/index.ts
@@ -6,3 +6,4 @@
 
 export { readmePlugin, ReadmeCard } from './plugin';
 export type { ReadmeCardProps } from './components/ReadmeCard';
+export { isReadmeAvailable } from './api/ReadmeClient';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,6 +1532,7 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.6.6"
     "@backstage/catalog-model": "npm:^1.6.0"
     "@backstage/cli": "npm:^0.27.0"
+    "@backstage/errors": "npm:^1.2.4"
     "@backstage/integration": "npm:^1.14.0"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^2.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,6 +1552,7 @@ __metadata:
     "@backstage/core-components": "npm:^0.14.10"
     "@backstage/core-plugin-api": "npm:^1.9.3"
     "@backstage/dev-utils": "npm:^1.0.37"
+    "@backstage/errors": "npm:^1.2.4"
     "@backstage/plugin-catalog-react": "npm:^1.12.3"
     "@backstage/test-utils": "npm:^1.5.10"
     "@backstage/theme": "npm:^0.5.6"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changes:
- New function "isReadmeAvailable" is now exported from the Readme-plugin. This function return true or false based on if backend returns 404 error. 
- EntitySwitch and EntitySwitch.Case has been added to the EntityPage in app. 

### Context

Our usability tests show that the EntityPage sometimes gets very cluttered with a lot of information. This results in that the users can't find what they are looking for. We want to fix this by making it possible to not render any ReadmeCard at all, if the README.md is not available (backend returns 404 Not Found). 

### Screenshots 

#### Before
![Screenshot from 2024-10-07 15-07-20](https://github.com/user-attachments/assets/907f2468-dde5-424f-9b09-f2c1c0f63394)

_The "No README.md file found at source location"-text is displayed_


#### After
![Screenshot from 2024-10-07 15-07-39](https://github.com/user-attachments/assets/94fcaf7d-25f0-4461-9c7c-882e211325ca)

_No card is displayed_


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
