### PR TITLE
feat(readme): add maxHeight prop to ReadmeCard component

### DIFF
--- a/.changeset/happy-ghosts-invent.md
+++ b/.changeset/happy-ghosts-invent.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme': minor
+---
+
+Add new maxHeight property to ReadmeCard component

--- a/plugins/readme/api-report.md
+++ b/plugins/readme/api-report.md
@@ -16,6 +16,7 @@ export const ReadmeCard: (props: ReadmeCardProps) => JSX_2.Element;
 // @public
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
+  maxHeight?: string | number;
 };
 
 // @public

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -14,11 +14,13 @@ import { ReadmeDialog } from '../ReadmeDialog/ReadmeDialog';
 
 export type ReadmeCardProps = {
   variant?: InfoCardVariants;
+  maxHeight?: string | number;
 };
 
 export const ReadmeCard = (props: ReadmeCardProps) => {
-  const { variant = 'gridItem' } = props;
-  const maxHeight = variant === 'fullHeight' ? 'none' : '235px';
+  const { variant = 'gridItem', maxHeight: propMaxHeight } = props;
+  const maxHeight =
+    variant === 'fullHeight' ? 'none' : propMaxHeight ?? '235px';
 
   const [displayDialog, setDisplayDialog] = useState(false);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enhance the ReadmeCard component to allow custom max height settings. This change provides more flexibility in controlling the card's appearance across different layouts and screen sizes.

### Context

The new maxHeight prop allows users to override the default height of 235px for non-fullHeight variants, enabling better customization of the component's vertical space.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
