### PR TITLE
Add support for multiple Jira instances

### DIFF
--- a/.changeset/old-pumas-bathe.md
+++ b/.changeset/old-pumas-bathe.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Add support for multiple Jira instances

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -43,6 +43,33 @@ jiraDashboard:
   annotationPrefix: jira
 ```
 
+### Multiple Jira instances
+
+In case multiple Jira instances are being used, the configuration can be written on the form:
+
+```yaml
+jiraDashboard:
+  annotationPrefix: ${JIRA_ANNOTATION_PREFIX} # Optional
+  instances:
+    - name: default
+      token: ${JIRA_TOKEN}
+      baseUrl: ${JIRA_BASE_URL}
+      userEmailSuffix: ${JIRA_EMAIL_SUFFIX} # Optional
+    - name: separate-jira-instance
+      token: ${JIRA_TOKEN_SEPARATE}
+      baseUrl: ${JIRA_BASE_URL_SEPARATE}
+      userEmailSuffix: ${JIRA_EMAIL_SUFFIX_SEPARATE} # Optional
+```
+
+In entity yamls that don't specify an instance, the one called `"default"` will be used. To specify another instace, use the `jira.com/instance` annotation such as:
+
+```yaml
+metadata:
+  annotations:
+    jira.com/instance: separate-jira-instance
+    jira.com/project-key: value
+```
+
 #### Authentication examples and trouble shooting
 
 Either "Basic Auth" or "Personal Acccess Tokens" can be used.

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -61,13 +61,12 @@ jiraDashboard:
       userEmailSuffix: ${JIRA_EMAIL_SUFFIX_SEPARATE} # Optional
 ```
 
-In entity yamls that don't specify an instance, the one called `"default"` will be used. To specify another instace, use the `jira.com/instance` annotation such as:
+In entity yamls that don't specify an instance, the one called `"default"` will be used. To specify another instace, prefix the project key with `instance-name/` such as:
 
 ```yaml
 metadata:
   annotations:
-    jira.com/instance: separate-jira-instance
-    jira.com/project-key: value
+    jira.com/project-key: separate-jira-instance/my-project-key
 ```
 
 #### Authentication examples and trouble shooting

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -5,7 +5,13 @@
 ```ts
 import { BackendFeatureCompat } from '@backstage/backend-plugin-api';
 import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
-import { RootConfigService } from '@backstage/backend-plugin-api';
+
+// @public
+export type ConfigInstance = {
+  token: string;
+  baseUrl: string;
+  userEmailSuffix?: string;
+};
 
 // @public
 const jiraDashboardPlugin: BackendFeatureCompat;
@@ -27,7 +33,7 @@ export type JqlQueryBuilderArgs = {
 
 // @public
 export const searchJira: (
-  config: RootConfigService,
+  instance: ConfigInstance,
   jqlQuery: string,
   options: SearchOptions,
 ) => Promise<Issue[]>;

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -1,25 +1,58 @@
 export interface Config {
   /** Configuration options for the Jira Dashboard plugin */
-  jiraDashboard: {
-    /**
-     * The API token to authenticate towards Jira. It can be found by visiting Atlassians page at https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
-     * @visibility secret
-     */
-    token: string;
+  jiraDashboard:
+    | {
+        /**
+         * The API token to authenticate towards Jira. It can be found by visiting Atlassians page at https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
+         * @visibility secret
+         */
+        token: string;
 
-    /**
-     * The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
-     */
-    baseUrl: string;
+        /**
+         * The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
+         */
+        baseUrl: string;
 
-    /**
-     * Optional email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com. If not provided, the user entity profile email is used instead.
-     */
-    userEmailSuffix?: string;
+        /**
+         * Optional email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com. If not provided, the user entity profile email is used instead.
+         */
+        userEmailSuffix?: string;
 
-    /**
-     * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
-     */
-    annotationPrefix?: string;
-  };
+        /**
+         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         */
+        annotationPrefix?: string;
+
+        // Type helper
+        instances?: never;
+      }
+    | {
+        /**
+         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         */
+        annotationPrefix?: string;
+
+        instances: {
+          /**
+           * Instance name. This is used in entity annotations to refer to the right instance. In entity annotations, this defaults to "default".
+           */
+          name: string;
+
+          /**
+           * The API token to authenticate towards Jira. It can be found by visiting Atlassians page at https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
+           * @visibility secret
+           */
+          token: string;
+
+          /**
+           * The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
+           */
+          baseUrl: string;
+
+          /**
+           * Optional email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com. If not provided, the user entity profile email is used instead.
+           */
+          userEmailSuffix?: string;
+        }[];
+      };
 }

--- a/plugins/jira-dashboard-backend/package.json
+++ b/plugins/jira-dashboard-backend/package.json
@@ -35,6 +35,7 @@
     "@backstage/backend-plugin-api": "^0.8.0",
     "@backstage/catalog-client": "^1.6.6",
     "@backstage/catalog-model": "^1.6.0",
+    "@backstage/errors": "^1.2.4",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "node-fetch": "^2.6.7"

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -7,11 +7,12 @@ import {
 
 import type { ConfigInstance } from './config';
 import { jqlQueryBuilder } from './queries';
+import type { JiraProject } from './lib';
 
 export const getProjectInfo = async (
-  projectKey: string,
-  instance: ConfigInstance,
+  project: JiraProject,
 ): Promise<Project> => {
+  const { projectKey, instance } = project;
   const response = await fetch(`${instance.baseUrl}project/${projectKey}`, {
     method: 'GET',
     headers: {
@@ -46,11 +47,11 @@ export const getFilterById = async (
 };
 
 export const getIssuesByFilter = async (
-  projectKey: string,
+  project: JiraProject,
   components: string[],
   query: string,
-  instance: ConfigInstance,
 ): Promise<Issue[]> => {
+  const { projectKey, instance } = project;
   const jql = jqlQueryBuilder({ project: projectKey, components, query });
   const response = await fetch(`${instance.baseUrl}search?jql=${jql}`, {
     method: 'GET',
@@ -107,10 +108,11 @@ export const searchJira = async (
 };
 
 export const getIssuesByComponent = async (
-  projectKey: string,
+  project: JiraProject,
   componentKey: string,
-  instance: ConfigInstance,
 ): Promise<Issue[]> => {
+  const { projectKey, instance } = project;
+
   const jql = jqlQueryBuilder({
     project: projectKey,
     components: [componentKey],

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -1,27 +1,24 @@
-import { RootConfigService } from '@backstage/backend-plugin-api';
 import fetch from 'node-fetch';
 import {
   Filter,
   Issue,
   Project,
 } from '@axis-backstage/plugin-jira-dashboard-common';
-import { resolveJiraBaseUrl, resolveJiraToken } from './config';
+
+import type { ConfigInstance } from './config';
 import { jqlQueryBuilder } from './queries';
 
 export const getProjectInfo = async (
   projectKey: string,
-  config: RootConfigService,
+  instance: ConfigInstance,
 ): Promise<Project> => {
-  const response = await fetch(
-    `${resolveJiraBaseUrl(config)}project/${projectKey}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: resolveJiraToken(config),
-        Accept: 'application/json',
-      },
+  const response = await fetch(`${instance.baseUrl}project/${projectKey}`, {
+    method: 'GET',
+    headers: {
+      Authorization: instance.token,
+      Accept: 'application/json',
     },
-  );
+  });
   if (response.status !== 200) {
     throw Error(
       `Request failed with status code ${response.status}: ${response.statusText}`,
@@ -32,12 +29,12 @@ export const getProjectInfo = async (
 
 export const getFilterById = async (
   id: string,
-  config: RootConfigService,
+  instance: ConfigInstance,
 ): Promise<Filter> => {
-  const response = await fetch(`${resolveJiraBaseUrl(config)}filter/${id}`, {
+  const response = await fetch(`${instance.baseUrl}filter/${id}`, {
     method: 'GET',
     headers: {
-      Authorization: resolveJiraToken(config),
+      Authorization: instance.token,
       Accept: 'application/json',
     },
   });
@@ -52,19 +49,16 @@ export const getIssuesByFilter = async (
   projectKey: string,
   components: string[],
   query: string,
-  config: RootConfigService,
+  instance: ConfigInstance,
 ): Promise<Issue[]> => {
   const jql = jqlQueryBuilder({ project: projectKey, components, query });
-  const response = await fetch(
-    `${resolveJiraBaseUrl(config)}search?jql=${jql}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: resolveJiraToken(config),
-        Accept: 'application/json',
-      },
+  const response = await fetch(`${instance.baseUrl}search?jql=${jql}`, {
+    method: 'GET',
+    headers: {
+      Authorization: instance.token,
+      Accept: 'application/json',
     },
-  ).then(resp => resp.json());
+  }).then(resp => resp.json());
   return response.issues;
 };
 
@@ -96,15 +90,15 @@ export type SearchOptions = {
  * @public
  */
 export const searchJira = async (
-  config: RootConfigService,
+  instance: ConfigInstance,
   jqlQuery: string,
   options: SearchOptions,
 ): Promise<Issue[]> => {
-  const response = await fetch(`${resolveJiraBaseUrl(config)}search`, {
+  const response = await fetch(`${instance.baseUrl}search`, {
     method: 'POST',
     body: JSON.stringify({ jql: jqlQuery, ...options }),
     headers: {
-      Authorization: resolveJiraToken(config),
+      Authorization: instance.token,
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
@@ -115,30 +109,27 @@ export const searchJira = async (
 export const getIssuesByComponent = async (
   projectKey: string,
   componentKey: string,
-  config: RootConfigService,
+  instance: ConfigInstance,
 ): Promise<Issue[]> => {
   const jql = jqlQueryBuilder({
     project: projectKey,
     components: [componentKey],
   });
-  const response = await fetch(
-    `${resolveJiraBaseUrl(config)}search?jql=${jql}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: resolveJiraToken(config),
-        Accept: 'application/json',
-      },
+  const response = await fetch(`${instance.baseUrl}search?jql=${jql}`, {
+    method: 'GET',
+    headers: {
+      Authorization: instance.token,
+      Accept: 'application/json',
     },
-  ).then(resp => resp.json());
+  }).then(resp => resp.json());
   return response.issues;
 };
 
-export async function getProjectAvatar(url: string, config: RootConfigService) {
-  return await fetch(url, {
+export async function getProjectAvatar(url: string, instance: ConfigInstance) {
+  return fetch(url, {
     method: 'GET',
     headers: {
-      Authorization: resolveJiraToken(config),
+      Authorization: instance.token,
     },
   });
 }

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -1,12 +1,11 @@
 import { ConflictError, ServiceUnavailableError } from '@backstage/errors';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
-import type { Config } from '../config';
-
-export type ConfigInstance = Omit<
-  NonNullable<Config['jiraDashboard']['instances']>[number],
-  'name'
->;
+export interface ConfigInstance {
+  token: string;
+  baseUrl: string;
+  userEmailSuffix?: string;
+}
 
 const JIRA_CONFIG_BASE_URL = 'baseUrl';
 const JIRA_CONFIG_TOKEN = 'token';
@@ -37,7 +36,9 @@ export class JiraConfig {
         this.instances[name] = {
           token: inst.getString(JIRA_CONFIG_TOKEN),
           baseUrl: inst.getString(JIRA_CONFIG_BASE_URL),
-          userEmailSuffix: inst.getOptionalString(JIRA_CONFIG_USER_EMAIL_SUFFIX),
+          userEmailSuffix: inst.getOptionalString(
+            JIRA_CONFIG_USER_EMAIL_SUFFIX,
+          ),
         };
       });
     } else {

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -1,11 +1,16 @@
 import { ConflictError, ServiceUnavailableError } from '@backstage/errors';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
-export interface ConfigInstance {
+/**
+ * The configuration of a Jira instance
+ *
+ * @public
+ */
+export type ConfigInstance = {
   token: string;
   baseUrl: string;
   userEmailSuffix?: string;
-}
+};
 
 const JIRA_CONFIG_BASE_URL = 'baseUrl';
 const JIRA_CONFIG_TOKEN = 'token';

--- a/plugins/jira-dashboard-backend/src/filters.test.ts
+++ b/plugins/jira-dashboard-backend/src/filters.test.ts
@@ -1,15 +1,19 @@
 import { getDefaultFiltersForUser } from './filters';
 import { mockServices } from '@backstage/backend-test-utils';
 import { UserEntity } from '@backstage/catalog-model';
+import { ConfigInstance, JiraConfig } from './config';
 
 describe('getDefaultFiltersForUser', () => {
   const mockConfig = mockServices.rootConfig({
     data: {
       jiraDashboard: {
+        baseUrl: 'http://jira.com',
+        token: 'token',
         userEmailSuffix: '@backstage.com',
       },
     },
   });
+  const instance = JiraConfig.fromConfig(mockConfig).getInstance();
 
   const mockUserEntity: UserEntity = {
     apiVersion: 'backstage.io/v1beta1',
@@ -29,7 +33,7 @@ describe('getDefaultFiltersForUser', () => {
   };
 
   it('returns userEmailSuffix email when config is provided', () => {
-    const filters = getDefaultFiltersForUser(mockConfig, mockUserEntity);
+    const filters = getDefaultFiltersForUser(instance, mockUserEntity);
     expect(filters).toHaveLength(3);
     expect(filters).toContainEqual(
       expect.objectContaining({
@@ -41,7 +45,7 @@ describe('getDefaultFiltersForUser', () => {
 
   it('returns backstage email when userEmailSuffix config is not provided', () => {
     const filters = getDefaultFiltersForUser(
-      mockServices.rootConfig(),
+      {} as ConfigInstance,
       mockUserEntity,
     );
     expect(filters).toHaveLength(3);
@@ -54,7 +58,7 @@ describe('getDefaultFiltersForUser', () => {
   });
 
   it('do not return Assigned to me filter when userEntity is not provided', () => {
-    const filters = getDefaultFiltersForUser(mockConfig);
+    const filters = getDefaultFiltersForUser(instance);
     expect(filters).toHaveLength(2);
   });
 });

--- a/plugins/jira-dashboard-backend/src/filters.ts
+++ b/plugins/jira-dashboard-backend/src/filters.ts
@@ -1,7 +1,6 @@
-import { RootConfigService } from '@backstage/backend-plugin-api';
-import { resolveUserEmailSuffix } from './config';
 import { Filter } from '@axis-backstage/plugin-jira-dashboard-common';
 import { UserEntity } from '@backstage/catalog-model';
+import { ConfigInstance } from './config';
 
 const openFilter: Filter = {
   name: 'Open Issues',
@@ -23,10 +22,10 @@ const getIncomingFilter = (incomingStatus: string): Filter => ({
  * @param userEntity user entity instance
  */
 export const getAssigneUser = (
-  config: RootConfigService,
+  instance: ConfigInstance,
   userEntity: UserEntity,
 ): string => {
-  const emailSuffixConfig = resolveUserEmailSuffix(config);
+  const emailSuffixConfig = instance.userEmailSuffix;
 
   return emailSuffixConfig
     ? `${userEntity.metadata.name}${emailSuffixConfig}`
@@ -35,9 +34,9 @@ export const getAssigneUser = (
 
 const getAssignedToMeFilter = (
   userEntity: UserEntity,
-  config: RootConfigService,
+  instance: ConfigInstance,
 ): Filter => {
-  const email = getAssigneUser(config, userEntity);
+  const email = getAssigneUser(instance, userEntity);
 
   return {
     name: 'Assigned to me',
@@ -47,7 +46,7 @@ const getAssignedToMeFilter = (
 };
 
 export const getDefaultFiltersForUser = (
-  config: RootConfigService,
+  instance: ConfigInstance,
   userEntity?: UserEntity,
   incomingStatus?: string,
 ): Filter[] => {
@@ -55,7 +54,7 @@ export const getDefaultFiltersForUser = (
 
   if (!userEntity) return [openFilter, incomingFilter];
 
-  const assigneeToMeFilter = getAssignedToMeFilter(userEntity, config);
+  const assigneeToMeFilter = getAssignedToMeFilter(userEntity, instance);
 
   return [openFilter, incomingFilter, assigneeToMeFilter];
 };

--- a/plugins/jira-dashboard-backend/src/index.ts
+++ b/plugins/jira-dashboard-backend/src/index.ts
@@ -7,5 +7,6 @@
 export { jiraDashboardPlugin as default } from './plugin';
 export { searchJira } from './api';
 export type { SearchOptions } from './api';
+export type { ConfigInstance } from './config';
 export { jqlQueryBuilder } from './queries';
 export type { JqlQueryBuilderArgs } from './queries';

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -3,15 +3,13 @@ import {
   PROJECT_KEY_NAME,
   FILTERS_NAME,
   INCOMING_ISSUES_STATUS,
-  INSTANCE_NAME,
 } from '@axis-backstage/plugin-jira-dashboard-common';
 
-import { JiraConfig } from './config';
+import type { ConfigInstance, JiraConfig } from './config';
 
 export const getAnnotations = (config: JiraConfig) => {
   const prefix = config.annotationPrefix;
 
-  const instanceAnnotation = `${prefix}/${INSTANCE_NAME}`;
   const projectKeyAnnotation = `${prefix}/${PROJECT_KEY_NAME}`;
   const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
   const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
@@ -21,7 +19,6 @@ export const getAnnotations = (config: JiraConfig) => {
   const componentRoadieAnnotation = `${prefix}/component`;
 
   return {
-    instanceAnnotation,
     projectKeyAnnotation,
     componentsAnnotation,
     filtersAnnotation,
@@ -29,3 +26,34 @@ export const getAnnotations = (config: JiraConfig) => {
     componentRoadieAnnotation,
   };
 };
+
+export interface JiraProject {
+  instance: ConfigInstance;
+  fullProjectKey: string;
+  projectKey: string;
+}
+
+/**
+ * Splits a project key "instance/key" into a config instance and a project
+ * key, falling back to 'default' for unprefixed keys
+ */
+export function splitProjectKey(
+  config: JiraConfig,
+  fullProjectKey: string,
+): JiraProject {
+  const [instance, projectKey] = fullProjectKey.split('/');
+  if (!projectKey) {
+    // No specific instance specified - use default
+    return {
+      instance: config.getInstance(),
+      fullProjectKey,
+      projectKey: instance,
+    };
+  }
+
+  return {
+    instance: config.getInstance(instance),
+    fullProjectKey,
+    projectKey,
+  };
+}

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -1,15 +1,17 @@
-import { resolveAnnotationPrefix } from './config';
 import {
   COMPONENTS_NAME,
   PROJECT_KEY_NAME,
   FILTERS_NAME,
   INCOMING_ISSUES_STATUS,
+  INSTANCE_NAME,
 } from '@axis-backstage/plugin-jira-dashboard-common';
-import { RootConfigService } from '@backstage/backend-plugin-api';
 
-export const getAnnotations = (config: RootConfigService) => {
-  const prefix = resolveAnnotationPrefix(config);
+import { JiraConfig } from './config';
 
+export const getAnnotations = (config: JiraConfig) => {
+  const prefix = config.annotationPrefix;
+
+  const instanceAnnotation = `${prefix}/${INSTANCE_NAME}`;
   const projectKeyAnnotation = `${prefix}/${PROJECT_KEY_NAME}`;
   const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
   const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
@@ -19,6 +21,7 @@ export const getAnnotations = (config: RootConfigService) => {
   const componentRoadieAnnotation = `${prefix}/component`;
 
   return {
+    instanceAnnotation,
     projectKeyAnnotation,
     componentsAnnotation,
     filtersAnnotation,

--- a/plugins/jira-dashboard-backend/src/plugin.ts
+++ b/plugins/jira-dashboard-backend/src/plugin.ts
@@ -3,6 +3,7 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
+import { JiraConfig } from './config';
 
 /**
  * The Jira Dashboard backend plugin.
@@ -17,7 +18,7 @@ export const jiraDashboardPlugin = createBackendPlugin({
         auth: coreServices.auth,
         httpRouter: coreServices.httpRouter,
         logger: coreServices.logger,
-        config: coreServices.rootConfig,
+        rootConfig: coreServices.rootConfig,
         discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
         userInfo: coreServices.userInfo,
@@ -26,7 +27,7 @@ export const jiraDashboardPlugin = createBackendPlugin({
         auth,
         httpRouter,
         logger,
-        config,
+        rootConfig,
         discovery,
         httpAuth,
         userInfo,
@@ -35,7 +36,8 @@ export const jiraDashboardPlugin = createBackendPlugin({
           await createRouter({
             auth,
             logger,
-            config,
+            rootConfig,
+            config: JiraConfig.fromConfig(rootConfig),
             discovery,
             httpAuth,
             userInfo,

--- a/plugins/jira-dashboard-backend/src/service/router.test.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.test.ts
@@ -3,15 +3,20 @@ import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
+import { JiraConfig } from '../config';
 
 describe('createRouter', () => {
   let app: express.Express;
 
   beforeAll(async () => {
+    const rootConfig = mockServices.rootConfig({
+      data: { jiraDashboard: { instances: [] } },
+    });
     const router = await createRouter({
       auth: mockServices.auth.mock(),
       logger: mockServices.logger.mock(),
-      config: mockServices.rootConfig(),
+      rootConfig,
+      config: JiraConfig.fromConfig(rootConfig),
       discovery: mockServices.discovery.mock(),
       httpAuth: mockServices.httpAuth.mock(),
       userInfo: mockServices.userInfo.mock(),

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -1,4 +1,4 @@
-import { CacheService, RootConfigService } from '@backstage/backend-plugin-api';
+import { CacheService } from '@backstage/backend-plugin-api';
 import {
   type Filter,
   Issue,
@@ -14,10 +14,11 @@ import {
   SearchOptions,
 } from '../api';
 import { jqlQueryBuilder } from '../queries';
+import type { ConfigInstance } from '../config';
 
 export const getProjectResponse = async (
   projectKey: string,
-  config: RootConfigService,
+  config: ConfigInstance,
   cache: CacheService,
 ): Promise<Project> => {
   let projectResponse: Project;
@@ -43,7 +44,7 @@ export const getProjectResponse = async (
 
 export const getJqlResponse = async (
   jql: string,
-  config: RootConfigService,
+  config: ConfigInstance,
   cache: CacheService,
   searchOptions: SearchOptions,
 ): Promise<Issue[]> => {
@@ -71,7 +72,7 @@ export const getJqlResponse = async (
 export const getUserIssues = async (
   username: string,
   maxResults: number,
-  config: RootConfigService,
+  config: ConfigInstance,
   cache: CacheService,
 ): Promise<Issue[]> => {
   const jql = `assignee = "${username}" AND resolution = Unresolved ORDER BY priority DESC, updated DESC`;
@@ -92,7 +93,7 @@ export const getUserIssues = async (
 
 export const getFiltersFromAnnotations = async (
   annotations: string[],
-  config: RootConfigService,
+  config: ConfigInstance,
 ): Promise<Filter[]> => {
   const filters: Filter[] = [];
 
@@ -113,7 +114,7 @@ export const getIssuesFromFilters = async (
   projectKey: string,
   components: string[],
   filters: Filter[],
-  config: RootConfigService,
+  config: ConfigInstance,
 ): Promise<JiraDataResponse[]> => {
   return await Promise.all(
     filters.map(async filter => ({
@@ -137,7 +138,7 @@ export const getIssuesFromFilters = async (
 export const getIssuesFromComponents = async (
   projectKey: string,
   componentAnnotations: string[],
-  config: RootConfigService,
+  config: ConfigInstance,
 ): Promise<JiraDataResponse[]> => {
   return await Promise.all(
     componentAnnotations.map(async componentKey => ({

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -1,6 +1,9 @@
 /**
  * The annotation name used to provide the key of the Jira project to track for this entity
  *
+ * If this project is not in the default Jira instance, it can be prefixed with
+ * `instance-name/`.
+ *
  *  @public
  */
 export const PROJECT_KEY_NAME = 'project-key';
@@ -22,10 +25,3 @@ export const FILTERS_NAME = 'filter-ids';
  *  @public
  */
 export const INCOMING_ISSUES_STATUS = 'incoming-issues-status';
-
-/**
- * The annotation name used to specify which Jira instance to use.
- * Defaults to 'default'.
- *  @public
- */
-export const INSTANCE_NAME = 'instance';

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -22,3 +22,10 @@ export const FILTERS_NAME = 'filter-ids';
  *  @public
  */
 export const INCOMING_ISSUES_STATUS = 'incoming-issues-status';
+
+/**
+ * The annotation name used to specify which Jira instance to use.
+ * Defaults to 'default'.
+ *  @public
+ */
+export const INSTANCE_NAME = 'instance';

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -105,6 +105,8 @@ If you want to track specific components or filters for your entity, you can add
 
 If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status` annotation.
 
+In case of multiple Jira instances being used, specify the instance using the `instance` annotation (defaulting to `"default"`).
+
 ```yaml
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -115,6 +117,7 @@ metadata:
     jira.com/components: component,component,component # Jira component name separated with a comma. The Roadie Backstage Jira Plugin Jira annotation `/component` is also supported here by default
     jira.com/filter-ids: 12345,67890 # Jira filter id separated with a comma
     jira.com/incoming-issues-status: Incoming # The name of the status for incoming issues in Jira. Default: New
+    jira.com/instance: separate-jira-instance # The instance name, if not the default
 ```
 
 ### New Frontend System (Alpha)

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -105,7 +105,7 @@ If you want to track specific components or filters for your entity, you can add
 
 If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status` annotation.
 
-In case of multiple Jira instances being used, specify the instance using the `instance` annotation (defaulting to `"default"`).
+In case of multiple Jira instances being used, specify the instance by prefixing the `jira.com/project-key` with `instance-name/` (defaulting to `"default"`).
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
@@ -113,11 +113,10 @@ kind: Component
 metadata:
   # ...
   annotations:
-    jira.com/project-key: value # The key of the Jira project to track for this entity
+    jira.com/project-key: another-instance/value # The key of the Jira project to track for this entity, optionally prefixed with the instance name
     jira.com/components: component,component,component # Jira component name separated with a comma. The Roadie Backstage Jira Plugin Jira annotation `/component` is also supported here by default
     jira.com/filter-ids: 12345,67890 # Jira filter id separated with a comma
     jira.com/incoming-issues-status: Incoming # The name of the status for incoming issues in Jira. Default: New
-    jira.com/instance: separate-jira-instance # The instance name, if not the default
 ```
 
 ### New Frontend System (Alpha)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,7 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.6.6"
     "@backstage/catalog-model": "npm:^1.6.0"
     "@backstage/cli": "npm:^0.27.0"
+    "@backstage/errors": "npm:^1.2.4"
     "@backstage/plugin-auth-backend": "npm:^0.23.0"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.0"
     "@types/express": "npm:*"


### PR DESCRIPTION
## Multi instance support

This PR adds support for multiple Jira instances. The configuration format can be used as today, or by adding an `instances` array of Jira instances, as described in the README changes.

### Context

For companies using multiple Jira instances, this PR enables them to use this. One instance can be called `default`, in which case entities don't need to specify the instance, ~and for other entities, the annotation `jira.com/instance` is used~ otherwise the `project-key` can be prefixed with `instance-name/` similar to the [SonarQube configuration](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube-backend#catalog-1).

### Issue ticket number and link

- Fixes #198 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
