### PR TITLE
Fixed caching of user issues when having multiple Jira issues

### DIFF
--- a/.changeset/fast-radios-sing.md
+++ b/.changeset/fast-radios-sing.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Fixed caching of user issues when having multiple Jira instances.

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -50,15 +50,17 @@ export const getJqlResponse = async (
 ): Promise<Issue[]> => {
   let issuesResponse: Issue[];
 
-  issuesResponse = (await cache.get(jql)) as Issue[];
+  const cacheKey = `${config.baseUrl} ${jql}`;
+
+  issuesResponse = (await cache.get(cacheKey)) as Issue[];
 
   if (issuesResponse) {
-    return issuesResponse as Issue[];
+    return issuesResponse;
   }
 
   try {
     issuesResponse = (await searchJira(config, jql, searchOptions)).issues;
-    cache.set(jql, issuesResponse);
+    cache.set(cacheKey, issuesResponse);
   } catch (err: any) {
     if (err.message !== 200) {
       throw Error(


### PR DESCRIPTION
## Multi-instance fix for user issues

After #202, I found that the user issues view produced a little weird result (which obviously passed me by before). The cache key used in those queries are identical for ever Jira instance, so the cache will be filled with one of them, overwriting the other.

This PR fixes this by prepending the instance url to the cache key, so they become unique for every [user+instance].

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
