### PR TITLE
Add support for configuring custom headers for API requests

### DIFF
--- a/.changeset/curly-terms-yawn.md
+++ b/.changeset/curly-terms-yawn.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Added support for configuring custom headers for API requests

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -25,6 +25,7 @@ The Jira Dashboard plugin requires the following YAML to be added to your app-co
 jiraDashboard:
   token: ${JIRA_TOKEN}
   baseUrl: ${JIRA_BASE_URL}
+  headers: {} # Optional
   userEmailSuffix: ${JIRA_EMAIL_SUFFIX} # Optional
   annotationPrefix: ${JIRA_ANNOTATION_PREFIX} # Optional
 ```
@@ -34,6 +35,7 @@ jiraDashboard:
 - `JIRA_TOKEN`: The "Authorization" header used for Jira authentication.
   > Note: The JIRA_TOKEN variable from [Roadie's Backstage Jira plugin](https://roadie.io/backstage/plugins/jira) can not be reused here because of the added encoding in this token.
 - `JIRA_BASE_URL`: The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/
+- The headers field can be used to add HTTP headers that will be added to the API requests.
 - `JIRA_EMAIL_SUFFIX`: Optional email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com. If not provided, the user entity profile email is used instead.
 - `JIRA_ANNOTATION_PREFIX`: Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com. If you want to configure the plugin to be compatible with [Roadie's Backstage Jira Plugin](https://roadie.io/backstage/plugins/jira/), use the following annotation prefix:
 
@@ -54,10 +56,12 @@ jiraDashboard:
     - name: default
       token: ${JIRA_TOKEN}
       baseUrl: ${JIRA_BASE_URL}
+      headers: {} # Optional
       userEmailSuffix: ${JIRA_EMAIL_SUFFIX} # Optional
     - name: separate-jira-instance
       token: ${JIRA_TOKEN_SEPARATE}
       baseUrl: ${JIRA_BASE_URL_SEPARATE}
+      headers: {} # Optional
       userEmailSuffix: ${JIRA_EMAIL_SUFFIX_SEPARATE} # Optional
 ```
 

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -9,6 +9,7 @@ import { JiraQueryResults } from '@axis-backstage/plugin-jira-dashboard-common';
 // @public
 export type ConfigInstance = {
   token: string;
+  headers: Record<string, string>;
   baseUrl: string;
   userEmailSuffix?: string;
 };

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -9,6 +9,14 @@ export interface Config {
         token: string;
 
         /**
+         * Optional headers to pass the HTTP requests
+         */
+        headers?: {
+          /** @visibility secret */
+          [key: string]: string | undefined;
+        };
+
+        /**
          * The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'
          */
         baseUrl: string;
@@ -43,6 +51,14 @@ export interface Config {
            * @visibility secret
            */
           token: string;
+
+          /**
+           * Optional headers to pass the HTTP requests
+           */
+          headers?: {
+            /** @visibility secret */
+            [key: string]: string | undefined;
+          };
 
           /**
            * The base url for Jira in your company, including the API version. For instance: https://jira.se.your-company.com/rest/api/2/'

--- a/plugins/jira-dashboard-backend/src/api.test.ts
+++ b/plugins/jira-dashboard-backend/src/api.test.ts
@@ -1,0 +1,73 @@
+import fetch from 'node-fetch';
+
+import { mockServices } from '@backstage/backend-test-utils';
+
+import { getIssuesByComponent, getProjectAvatar } from './api';
+import { JiraConfig } from './config';
+
+jest.mock('node-fetch', () => jest.fn());
+
+describe('api', () => {
+  const mockConfig = mockServices.rootConfig({
+    data: {
+      jiraDashboard: {
+        baseUrl: 'http://jira.com/',
+        token: 'token',
+        headers: {
+          'Custom-Header': 'custom value',
+        },
+        userEmailSuffix: '@backstage.com',
+      },
+    },
+  });
+
+  const instance = JiraConfig.fromConfig(mockConfig).getInstance();
+
+  it('getProjectAvatar', async () => {
+    await getProjectAvatar('http://jira.com/', instance);
+
+    expect(fetch).toHaveBeenCalledWith('http://jira.com/', {
+      method: 'GET',
+      headers: {
+        'Custom-Header': 'custom value',
+        Authorization: 'token',
+      },
+    });
+  });
+
+  it('getIssuesByComponent', async () => {
+    const response = Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => {
+        return { issues: ['issue1'] };
+      },
+    });
+    (fetch as jest.MockedFn<typeof fetch>).mockImplementation(
+      () => response as any,
+    );
+
+    const issues = await getIssuesByComponent(
+      {
+        instance,
+        fullProjectKey: 'default/ppp',
+        projectKey: 'ppp',
+      },
+      'ccc',
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://jira.com/search?jql=project in (ppp) AND component in ('ccc')",
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Custom-Header': 'custom value',
+          Authorization: 'token',
+        },
+      },
+    );
+
+    expect(issues).toEqual(['issue1']);
+  });
+});

--- a/plugins/jira-dashboard-backend/src/config.test.ts
+++ b/plugins/jira-dashboard-backend/src/config.test.ts
@@ -1,0 +1,119 @@
+import { mockServices } from '@backstage/backend-test-utils';
+
+import { JiraConfig } from './config';
+
+describe('config', () => {
+  it('should handle a regular config', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        jiraDashboard: {
+          baseUrl: 'http://jira.com',
+          token: 'token',
+          userEmailSuffix: '@backstage.com',
+        },
+      },
+    });
+    const instance = JiraConfig.fromConfig(mockConfig).getInstance();
+    expect(instance.baseUrl).toBe('http://jira.com');
+    expect(instance.token).toBe('token');
+    expect(instance.headers).toEqual({});
+    expect(instance.userEmailSuffix).toBe('@backstage.com');
+  });
+
+  it('should handle custom headers', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        jiraDashboard: {
+          baseUrl: 'http://jira.com',
+          token: 'token',
+          headers: {
+            'Custom-Header': 'custom value',
+          },
+          userEmailSuffix: '@backstage.com',
+        },
+      },
+    });
+    const instance = JiraConfig.fromConfig(mockConfig).getInstance();
+    expect(instance.baseUrl).toBe('http://jira.com');
+    expect(instance.token).toBe('token');
+    expect(instance.headers).toEqual({ 'Custom-Header': 'custom value' });
+    expect(instance.userEmailSuffix).toBe('@backstage.com');
+  });
+
+  it('should handle multi-instance config', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        jiraDashboard: {
+          instances: [
+            {
+              name: 'default',
+              baseUrl: 'http://jira.com',
+              token: 'token',
+              userEmailSuffix: '@backstage.com',
+            },
+            {
+              name: 'other',
+              baseUrl: 'http://jira2.com',
+              token: 'token2',
+              userEmailSuffix: '@backstage2.com',
+            },
+          ],
+        },
+      },
+    });
+    const instance = JiraConfig.fromConfig(mockConfig).getInstance();
+    expect(instance.baseUrl).toBe('http://jira.com');
+    expect(instance.token).toBe('token');
+    expect(instance.headers).toEqual({});
+    expect(instance.userEmailSuffix).toBe('@backstage.com');
+    expect(instance).toEqual(
+      JiraConfig.fromConfig(mockConfig).getInstance('default'),
+    );
+
+    const instance2 = JiraConfig.fromConfig(mockConfig).getInstance('other');
+    expect(instance2.baseUrl).toBe('http://jira2.com');
+    expect(instance2.token).toBe('token2');
+    expect(instance2.headers).toEqual({});
+    expect(instance2.userEmailSuffix).toBe('@backstage2.com');
+  });
+
+  it('should handle multi-instance custom headers', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        jiraDashboard: {
+          instances: [
+            {
+              name: 'default',
+              baseUrl: 'http://jira.com',
+              token: 'token',
+              headers: {
+                'Custom-Header': 'custom value',
+              },
+              userEmailSuffix: '@backstage.com',
+            },
+            {
+              name: 'other',
+              baseUrl: 'http://jira2.com',
+              token: 'token2',
+              headers: {
+                'Other-Header': 'other value',
+              },
+              userEmailSuffix: '@backstage2.com',
+            },
+          ],
+        },
+      },
+    });
+    const instance = JiraConfig.fromConfig(mockConfig).getInstance();
+    expect(instance.baseUrl).toBe('http://jira.com');
+    expect(instance.token).toBe('token');
+    expect(instance.headers).toEqual({ 'Custom-Header': 'custom value' });
+    expect(instance.userEmailSuffix).toBe('@backstage.com');
+
+    const instance2 = JiraConfig.fromConfig(mockConfig).getInstance('other');
+    expect(instance2.baseUrl).toBe('http://jira2.com');
+    expect(instance2.token).toBe('token2');
+    expect(instance2.headers).toEqual({ 'Other-Header': 'other value' });
+    expect(instance2.userEmailSuffix).toBe('@backstage2.com');
+  });
+});


### PR DESCRIPTION
## Custom headers for API requests

This PR adds support for injecting custom headers into the API calls made to the Jira server.

The `api.ts` was refactored slightly, to instead of calling `fetch()` in each API function, call a new `callApi` which uses `fetch`, but also injects the custom headers and Authorization token too, to prevent future mistakes of missing the headers in new functions.

Some tests where added too, for the config, and for some API calls.

### Context

If the Jira server is behind an authorizing proxy, extra headers need to be sent to authorize against this proxy, while the `Authorization` header is passed on to the Jira server behind the proxy. This is why the ability to configure custom headers is necessary.

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
