### PR TITLE
Extracted the table part of the JiraUserIssuesViewCard

### DIFF
--- a/.changeset/five-seas-itch.md
+++ b/.changeset/five-seas-itch.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Extracted the table component from JiraUserIssuesViewCard into an exported component JiraUserIssuesTable, and added styling options to the table (or its outer Card) to adapt it more freely

--- a/plugins/jira-dashboard/api-report.md
+++ b/plugins/jira-dashboard/api-report.md
@@ -7,11 +7,14 @@
 
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { BottomLinkProps } from '@backstage/core-components';
+import { CSSProperties } from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraResponse } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JSX as JSX_2 } from 'react';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
+import { Table } from '@backstage/core-components';
 import { TableFilter } from '@backstage/core-components';
 
 // @public
@@ -54,11 +57,30 @@ export type JiraUserIssuesCardProps = {
 };
 
 // @public
+export const JiraUserIssuesTable: ({
+  title,
+  maxResults,
+  tableStyle,
+  style,
+}: JiraUserIssuesTableProps) => JSX_2.Element | null;
+
+// @public
+export type JiraUserIssuesTableProps = {
+  title?: string;
+  maxResults?: number;
+  tableStyle?: TableComponentProps['style'];
+  style?: CSSProperties;
+};
+
+// @public
 export const JiraUserIssuesViewCard: ({
   title,
   maxResults,
   bottomLinkProps,
-}: JiraUserIssuesCardProps) => JSX_2.Element | null;
+}: JiraUserIssuesCardProps) => JSX_2.Element;
+
+// @public
+export type TableComponentProps = React_2.ComponentProps<typeof Table>;
 
 // @public
 export function useJira(

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -93,6 +93,13 @@ export const JiraDashboardContent = (props?: {
                   tableContent={value}
                   showFilters={props?.showFilters}
                   project={jiraResponse.project}
+                  tableStyle={{
+                    height: 'max-content',
+                    maxHeight: '500px',
+                    padding: '20px',
+                    overflowY: 'auto',
+                    width: '100%',
+                  }}
                 />
               </Grid>
             ))}

--- a/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraTable/JiraTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import Typography from '@mui/material/Typography';
 import {
   Issue,
@@ -24,6 +24,13 @@ type Props = {
   tableContent: JiraDataResponse;
   tableColumns?: TableColumn<Issue>[];
   tableStyle?: TableComponentProps['style'];
+  /**
+   * CSS styles to apply to the top-most element, being the table component or
+   * the wrapping InfoCard component if filters are shown.
+   * If no filters are shown, the style prop is merged with the tableStyle prop
+   * and used in the table component.
+   */
+  style?: CSSProperties;
   showFilters?: TableFilter[] | boolean;
   project?: Project;
 };
@@ -31,13 +38,8 @@ type Props = {
 export const JiraTable = ({
   tableContent,
   tableColumns = columns,
-  tableStyle = {
-    height: 'max-content',
-    maxHeight: '500px',
-    padding: '20px',
-    overflowY: 'auto',
-    width: '100%',
-  },
+  tableStyle,
+  style,
   showFilters,
   project,
 }: Props) => {
@@ -90,7 +92,7 @@ export const JiraTable = ({
 
   if (showFilters) {
     return (
-      <InfoCard title={title}>
+      <InfoCard title={title} headerStyle={style}>
         <Table<Issue>
           options={{
             paging: false,
@@ -106,9 +108,9 @@ export const JiraTable = ({
           data={tableContent.issues || []}
           columns={tableColumns}
           style={{
-            ...tableStyle,
             padding: '0px',
             boxShadow: 'none',
+            ...tableStyle,
           }}
         />
       </InfoCard>
@@ -131,7 +133,7 @@ export const JiraTable = ({
       }
       data={tableContent.issues || []}
       columns={tableColumns}
-      style={tableStyle}
+      style={{ ...tableStyle, ...style }}
     />
   );
 };

--- a/plugins/jira-dashboard/src/components/JiraUserIssuesCard/JiraUserIssuesCard.tsx
+++ b/plugins/jira-dashboard/src/components/JiraUserIssuesCard/JiraUserIssuesCard.tsx
@@ -1,24 +1,8 @@
-import {
-  BottomLinkProps,
-  InfoCard,
-  Progress,
-  ResponseErrorPanel,
-  TableColumn,
-} from '@backstage/core-components';
-
 import React from 'react';
-import {
-  columnKey,
-  columnPriority,
-  columnStatus,
-  columnSummary,
-  columnUpdated,
-  JiraTable,
-} from '../JiraTable';
-import { useApi } from '@backstage/core-plugin-api';
-import { jiraDashboardApiRef } from '../../api';
-import { useJiraUserIssues } from '../../hooks/useJiraUserIssues';
-import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
+
+import { BottomLinkProps, InfoCard } from '@backstage/core-components';
+
+import { JiraUserIssuesTable } from '../JiraUserIssuesTable/JiraUserIssuesTable';
 
 /**
  * Jira user issues list card properties
@@ -29,63 +13,26 @@ export type JiraUserIssuesCardProps = {
   bottomLinkProps?: BottomLinkProps;
 };
 
-export const userColumns: TableColumn<Issue>[] = [
-  columnKey,
-  columnSummary,
-  columnPriority,
-  columnStatus,
-  columnUpdated,
-];
-
 /**
  * Jira user issues list card.
  * @public */
 export const JiraUserIssuesCard = ({
-  title = 'My open issues',
-  maxResults = 15,
+  title,
+  maxResults,
   bottomLinkProps,
 }: JiraUserIssuesCardProps) => {
-  const api = useApi(jiraDashboardApiRef);
-
-  const {
-    data: jiraResponse,
-    loading,
-    error,
-  } = useJiraUserIssues(maxResults, api);
-
-  if (loading) {
-    return <Progress />;
-  }
-  if (error) {
-    return <ResponseErrorPanel error={error} />;
-  }
-  if (!jiraResponse) {
-    return (
-      <ResponseErrorPanel
-        error={Error('Could not fetch Jira issues for user')}
+  return (
+    <InfoCard variant="fullHeight" deepLink={bottomLinkProps}>
+      <JiraUserIssuesTable
+        title={title}
+        maxResults={maxResults}
+        tableStyle={{
+          height: '500px',
+          padding: '0px',
+          overflowY: 'auto',
+          width: '100%',
+        }}
       />
-    );
-  }
-
-  if (jiraResponse) {
-    return (
-      <InfoCard variant="fullHeight" deepLink={bottomLinkProps}>
-        <JiraTable
-          tableContent={{
-            name: title,
-            type: 'component',
-            issues: jiraResponse,
-          }}
-          tableColumns={userColumns}
-          tableStyle={{
-            height: '500px',
-            padding: '0px',
-            overflowY: 'auto',
-            width: '100%',
-          }}
-        />
-      </InfoCard>
-    );
-  }
-  return null;
+    </InfoCard>
+  );
 };

--- a/plugins/jira-dashboard/src/components/JiraUserIssuesTable/JiraUserIssuesTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraUserIssuesTable/JiraUserIssuesTable.tsx
@@ -1,0 +1,93 @@
+import React, { CSSProperties } from 'react';
+
+import {
+  Progress,
+  ResponseErrorPanel,
+  TableColumn,
+  Table,
+} from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+
+import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
+
+import {
+  columnKey,
+  columnPriority,
+  columnStatus,
+  columnSummary,
+  columnUpdated,
+  JiraTable,
+} from '../JiraTable';
+import { jiraDashboardApiRef } from '../../api';
+import { useJiraUserIssues } from '../../hooks/useJiraUserIssues';
+
+/**
+ * Table properties for Table component in \@backstage/core-components
+ * @public */
+export type TableComponentProps = React.ComponentProps<typeof Table>;
+
+/**
+ * Jira user issues list card properties
+ * @public */
+export type JiraUserIssuesTableProps = {
+  title?: string;
+  maxResults?: number;
+  tableStyle?: TableComponentProps['style'];
+  style?: CSSProperties;
+};
+
+const userColumns: TableColumn<Issue>[] = [
+  columnKey,
+  columnSummary,
+  columnPriority,
+  columnStatus,
+  columnUpdated,
+];
+
+/**
+ * Jira user issues list table.
+ * @public */
+export const JiraUserIssuesTable = ({
+  title = 'My open issues',
+  maxResults = 15,
+  tableStyle,
+  style,
+}: JiraUserIssuesTableProps) => {
+  const api = useApi(jiraDashboardApiRef);
+
+  const {
+    data: jiraResponse,
+    loading,
+    error,
+  } = useJiraUserIssues(maxResults, api);
+
+  if (loading) {
+    return <Progress />;
+  }
+  if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+  if (!jiraResponse) {
+    return (
+      <ResponseErrorPanel
+        error={Error('Could not fetch Jira issues for user')}
+      />
+    );
+  }
+
+  if (jiraResponse) {
+    return (
+      <JiraTable
+        tableContent={{
+          name: title,
+          type: 'component',
+          issues: jiraResponse,
+        }}
+        tableColumns={userColumns}
+        tableStyle={tableStyle}
+        style={style}
+      />
+    );
+  }
+  return null;
+};

--- a/plugins/jira-dashboard/src/components/JiraUserIssuesTable/index.ts
+++ b/plugins/jira-dashboard/src/components/JiraUserIssuesTable/index.ts
@@ -1,0 +1,5 @@
+export type {
+  TableComponentProps,
+  JiraUserIssuesTableProps,
+} from './JiraUserIssuesTable';
+export { JiraUserIssuesTable } from './JiraUserIssuesTable';

--- a/plugins/jira-dashboard/src/index.ts
+++ b/plugins/jira-dashboard/src/index.ts
@@ -8,9 +8,14 @@ export {
   jiraDashboardPlugin,
   EntityJiraDashboardContent,
   JiraUserIssuesViewCard,
+  JiraUserIssuesTable,
   isJiraDashboardAvailable,
 } from './plugin';
 export { useJiraUserIssues } from './hooks/useJiraUserIssues';
 export { useJira } from './hooks/useJira';
 export type { JiraUserIssuesCardProps } from './components/JiraUserIssuesCard';
+export type {
+  TableComponentProps,
+  JiraUserIssuesTableProps,
+} from './components/JiraUserIssuesTable';
 export type { JiraDashboardApi } from './api/JiraDashboardApi';

--- a/plugins/jira-dashboard/src/plugin.ts
+++ b/plugins/jira-dashboard/src/plugin.ts
@@ -62,6 +62,21 @@ export const JiraUserIssuesViewCard = jiraDashboardPlugin.provide(
 /**
  * Jira content exported from the Jira Dashboard plugin
  * @public */
+export const JiraUserIssuesTable = jiraDashboardPlugin.provide(
+  createComponentExtension({
+    name: 'JiraUserIssuesTable',
+    component: {
+      lazy: () =>
+        import('./components/JiraUserIssuesTable').then(
+          m => m.JiraUserIssuesTable,
+        ),
+    },
+  }),
+);
+
+/**
+ * Jira content exported from the Jira Dashboard plugin
+ * @public */
 export const EntityJiraDashboardContent = jiraDashboardPlugin.provide(
   createRoutableExtension({
     name: 'EntityJiraDashboardContent',


### PR DESCRIPTION
## Separate the JiraUserIssuesViewCard into Card+Table components

The PR extracts the table part of the `JiraUserIssuesViewCard` component into a component called `JiraUserIssuesTable` and exports it. `JiraUserIssuesViewCard` now uses `JiraUserIssuesTable`. This means one can use the table component in places where a card isn't ideal. No visible change should have happened with this PR (as manually tested).

The style handling was changed too, so that one can style the table part and the card separately. It also moved the hard-coded defaults out from the `JiraTable` to where they where used. This allows an application to use the table component and render it in other layouts than the regular entity page grid - set width and height freely, etc.

### Context

When placing the user issues card/table in another kind of view - outside a Grid - the `JiraTable` had hard-coded defaults which intervened with the preferred layout. This PR mitigates that, by allowing custom CSS for the table (and/or its wrapping Card), while maintining the previous layout for the other components.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
