### PR TITLE
Support for user defined additional filters

### DIFF
--- a/.changeset/two-students-care.md
+++ b/.changeset/two-students-care.md
@@ -1,0 +1,8 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+---
+
+Support for user defined additional filters
+Issue https://github.com/AxisCommunications/backstage-plugins/issues/210
+
+Signed-off-by: enaysaa <saachi.nayyer@ericsson.com>

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -73,6 +73,28 @@ metadata:
     jira.com/project-key: separate-jira-instance/my-project-key
 ```
 
+### Custom Jira Filters
+
+You can define custom Jira filters directly in your `app-config.yaml` file. This allows you to create and display filters beyond the ones provided by the plugin.
+
+#### Configuration
+
+To add custom filters, use the `defaultFilters` property within a Jira instance configuration:
+
+```yaml
+jiraDashboard:
+  instances:
+    - name: my-jira-instance
+      # ... other configuration ...
+      defaultFilters:
+        - name: 'Open Bugs'
+          shortName: 'Bugs'
+          query: 'type = bug AND resolution = Unresolved ORDER BY updated DESC, priority DESC'
+        - name: 'Epics'
+          shortName: 'Epics'
+          query: 'type = epic AND resolution = Unresolved ORDER BY updated DESC, priority DESC'
+```
+
 #### Authentication examples and trouble shooting
 
 Either "Basic Auth" or "Personal Acccess Tokens" can be used.

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { BackendFeatureCompat } from '@backstage/backend-plugin-api';
+import { Filter } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraQueryResults } from '@axis-backstage/plugin-jira-dashboard-common';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
@@ -13,6 +14,7 @@ export type ConfigInstance = {
   headers: Record<string, string>;
   baseUrl: string;
   userEmailSuffix?: string;
+  defaultFilters?: Filter[];
 };
 
 // @public
@@ -21,6 +23,7 @@ export class JiraConfig {
   static fromConfig(config: RootConfigService): JiraConfig;
   getInstance(instanceName?: string): ConfigInstance;
   getInstances(): string[];
+  resolveDefaultFilters(instanceName: string): Filter[] | undefined;
   resolveJiraBaseUrl(instanceName: string): string;
   resolveJiraToken(instanceName: string): string;
   resolveUserEmailSuffix(instanceName: string): string | undefined;

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -31,6 +31,15 @@ export interface Config {
          */
         annotationPrefix?: string;
 
+        /**
+         * Optional default filters for Jira queries
+         */
+        defaultFilters?: {
+          name: string;
+          query: string;
+          shortName: string;
+        }[];
+
         // Type helper
         instances?: never;
       }
@@ -69,6 +78,15 @@ export interface Config {
            * Optional email suffix used for retrieving a specific Jira user in a company. For instance: @your-company.com. If not provided, the user entity profile email is used instead.
            */
           userEmailSuffix?: string;
+
+          /**
+           * Optional default filters for Jira queries
+           */
+          defaultFilters?: {
+            name: string;
+            query: string;
+            shortName: string;
+          }[];
         }[];
       };
 }

--- a/plugins/jira-dashboard-backend/src/config.test.ts
+++ b/plugins/jira-dashboard-backend/src/config.test.ts
@@ -116,4 +116,48 @@ describe('config', () => {
     expect(instance2.headers).toEqual({ 'Other-Header': 'other value' });
     expect(instance2.userEmailSuffix).toBe('@backstage2.com');
   });
+
+  it('should handle defaultFilters config', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        jiraDashboard: {
+          instances: [
+            {
+              name: 'default',
+              baseUrl: 'http://jira.com',
+              token: 'token',
+              defaultFilters: [
+                {
+                  name: 'My Open Bugs',
+                  shortName: 'MyBugs',
+                  query: 'type = Bug AND resolution = Unresolved',
+                },
+                {
+                  name: 'High Priority Issues',
+                  shortName: 'HighPrio',
+                  query: 'priority = "High"',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    const jiraConfig = JiraConfig.fromConfig(mockConfig);
+    const instance = jiraConfig.getInstance();
+
+    expect(instance.defaultFilters).toEqual([
+      {
+        name: 'My Open Bugs',
+        shortName: 'MyBugs',
+        query: 'type = Bug AND resolution = Unresolved',
+      },
+      {
+        name: 'High Priority Issues',
+        shortName: 'HighPrio',
+        query: 'priority = "High"',
+      },
+    ]);
+  });
 });

--- a/plugins/jira-dashboard-backend/src/filters.ts
+++ b/plugins/jira-dashboard-backend/src/filters.ts
@@ -52,9 +52,16 @@ export const getDefaultFiltersForUser = (
 ): Filter[] => {
   const incomingFilter = getIncomingFilter(incomingStatus ?? 'New');
 
-  if (!userEntity) return [openFilter, incomingFilter];
+  const defaultFilters =
+    instance.defaultFilters?.map(filter => ({
+      name: filter.name,
+      query: filter.query,
+      shortName: filter.shortName,
+    })) || [];
+
+  if (!userEntity) return [openFilter, incomingFilter, ...defaultFilters];
 
   const assigneeToMeFilter = getAssignedToMeFilter(userEntity, instance);
 
-  return [openFilter, incomingFilter, assigneeToMeFilter];
+  return [openFilter, incomingFilter, assigneeToMeFilter, ...defaultFilters];
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enhancement will allow user to add any additional filters in app-config other than these current default filters [openFilter, incomingFilter, assigneeToMeFilter].
for example
defaultFilters:
- name: 'Open Bugs'
shortName: 'Bugs'
query: 'type = bug AND resolution = Unresolved ORDER BY updated DESC, priority DESC'
- name: 'Epics'
shortName: 'Epics'
query: 'type = epic AND resolution = Unresolved ORDER BY updated DESC, priority DESC'


### Issue ticket number and link
https://github.com/AxisCommunications/backstage-plugins/issues/210

- Fixes # (issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
