### PR TITLE
feat(jira-backend): export the JiraConfig class

### DIFF
--- a/.changeset/grumpy-cups-act.md
+++ b/.changeset/grumpy-cups-act.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+The backend now exports the `JiraConfig` class. This is needed to create config
+instances for the `searchJira`function.

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { BackendFeatureCompat } from '@backstage/backend-plugin-api';
 import { JiraQueryResults } from '@axis-backstage/plugin-jira-dashboard-common';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 
 // @public
 export type ConfigInstance = {
@@ -13,6 +14,17 @@ export type ConfigInstance = {
   baseUrl: string;
   userEmailSuffix?: string;
 };
+
+// @public
+export class JiraConfig {
+  readonly annotationPrefix: string;
+  static fromConfig(config: RootConfigService): JiraConfig;
+  getInstance(instanceName?: string): ConfigInstance;
+  getInstances(): string[];
+  resolveJiraBaseUrl(instanceName: string): string;
+  resolveJiraToken(instanceName: string): string;
+  resolveUserEmailSuffix(instanceName: string): string | undefined;
+}
 
 // @public
 const jiraDashboardPlugin: BackendFeatureCompat;

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -33,8 +33,16 @@ const JIRA_CONFIG_HEADERS = 'headers';
 const JIRA_CONFIG_USER_EMAIL_SUFFIX = 'userEmailSuffix';
 const JIRA_CONFIG_ANNOTATION = 'annotationPrefix';
 
+/**
+ * Class for reading Jira configuration from the root config
+ *
+ * @public
+ */
 export class JiraConfig {
   private instances: Record<string, ConfigInstance> = {};
+  /**
+   * The annotation prefix to use for Jira annotations
+   */
   public readonly annotationPrefix: string;
 
   private constructor(config: RootConfigService) {
@@ -74,6 +82,9 @@ export class JiraConfig {
     }
   }
 
+  /**
+   * Create a JiraConfig from the root config
+   */
   public static fromConfig(config: RootConfigService): JiraConfig {
     return new JiraConfig(config);
   }
@@ -88,24 +99,39 @@ export class JiraConfig {
     return instance;
   }
 
+  /**
+   * Returns the configuration all instances
+   */
   getInstances() {
     return Object.getOwnPropertyNames(this.instances);
   }
 
+  /**
+   * Get the jira config for a specific instance
+   */
   getInstance(instanceName?: string): ConfigInstance {
     return this.forInstance(instanceName ?? 'default');
   }
 
+  /**
+   * Get the jira base url for a given instance
+   */
   resolveJiraBaseUrl(instanceName: string): string {
     const instance = this.forInstance(instanceName);
     return instance.baseUrl;
   }
 
+  /**
+   * Get the auth token for a given instance
+   */
   resolveJiraToken(instanceName: string): string {
     const instance = this.forInstance(instanceName);
     return instance.token;
   }
 
+  /**
+   * Get the email suffice for a given instance
+   */
   resolveUserEmailSuffix(instanceName: string): string | undefined {
     const instance = this.forInstance(instanceName);
     return instance.userEmailSuffix;

--- a/plugins/jira-dashboard-backend/src/index.ts
+++ b/plugins/jira-dashboard-backend/src/index.ts
@@ -8,5 +8,6 @@ export { jiraDashboardPlugin as default } from './plugin';
 export { searchJira } from './api';
 export type { SearchOptions } from './api';
 export type { ConfigInstance } from './config';
+export { JiraConfig } from './config';
 export { jqlQueryBuilder } from './queries';
 export type { JqlQueryBuilderArgs } from './queries';


### PR DESCRIPTION
This is needed to be able to use the exported searchJira function in other backend plugins since the jira config instance is now an argument.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [X] Added or updated documentation
