### PR TITLE
chore: export need files to manually register api

### DIFF
--- a/.changeset/thirty-houses-protect.md
+++ b/.changeset/thirty-houses-protect.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Export `jiraDashboardApiRef` and `JiraDashboardClient` for manual registration of the
+api.

--- a/plugins/jira-dashboard/api-report.md
+++ b/plugins/jira-dashboard/api-report.md
@@ -5,10 +5,13 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { BottomLinkProps } from '@backstage/core-components';
 import { CSSProperties } from 'react';
+import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraResponse } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JSX as JSX_2 } from 'react';
@@ -39,6 +42,17 @@ export type JiraDashboardApi = {
   getLoggedInUserIssues(maxResults: number): Promise<Issue[]>;
   getProjectAvatar(entityRef: string): any;
 };
+
+// @public
+export const jiraDashboardApiRef: ApiRef<JiraDashboardApi>;
+
+// @public
+export class JiraDashboardClient implements JiraDashboardApi {
+  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
+  getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
+  getLoggedInUserIssues(maxResults: number): Promise<Issue[]>;
+  getProjectAvatar(entityRef: string): Promise<string>;
+}
 
 // @public
 export const jiraDashboardPlugin: BackstagePlugin<

--- a/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
@@ -4,6 +4,11 @@ import {
   JiraResponse,
 } from '@axis-backstage/plugin-jira-dashboard-common';
 
+/**
+ * The apiref for the Jira dashboard plugin.
+ *
+ * @public
+ */
 export const jiraDashboardApiRef = createApiRef<JiraDashboardApi>({
   id: 'plugin.jira-dashboard',
 });

--- a/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
@@ -7,6 +7,11 @@ import { JiraDashboardApi } from './JiraDashboardApi';
 import { ResponseError } from '@backstage/errors';
 import { DEFAULT_NAMESPACE, parseEntityRef } from '@backstage/catalog-model';
 
+/**
+ * Client for fetching data from the Jira Dashboard backend.
+ *
+ * @public
+ */
 export class JiraDashboardClient implements JiraDashboardApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly fetchApi: FetchApi;
@@ -16,6 +21,9 @@ export class JiraDashboardClient implements JiraDashboardApi {
     this.fetchApi = options.fetchApi;
   }
 
+  /**
+   * Get Jira data for an entity.
+   */
   async getJiraResponseByEntity(entityRef: string): Promise<JiraResponse> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
     const { kind, name, namespace } = parseEntityRef(entityRef, {
@@ -34,6 +42,9 @@ export class JiraDashboardClient implements JiraDashboardApi {
     return resp.json();
   }
 
+  /**
+   * Get the Jira project avatar URL for an entity.
+   */
   async getProjectAvatar(entityRef: string): Promise<string> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
     const { kind, name, namespace } = parseEntityRef(entityRef, {
@@ -42,6 +53,9 @@ export class JiraDashboardClient implements JiraDashboardApi {
     return `${apiUrl}/avatar/by-entity-ref/${kind}/${namespace}/${name}`;
   }
 
+  /**
+   * Get the Jira issues for the calling user.
+   */
   async getLoggedInUserIssues(maxResults: number): Promise<Issue[]> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
 

--- a/plugins/jira-dashboard/src/index.ts
+++ b/plugins/jira-dashboard/src/index.ts
@@ -18,4 +18,6 @@ export type {
   TableComponentProps,
   JiraUserIssuesTableProps,
 } from './components/JiraUserIssuesTable';
+export { jiraDashboardApiRef } from './api/JiraDashboardApi';
 export type { JiraDashboardApi } from './api/JiraDashboardApi';
+export { JiraDashboardClient } from './api/JiraDashboardClient';


### PR DESCRIPTION
Export `jiraDashboardApiRef` and `JiraDashboardClient` for manual registration of the
api.