### PR TITLE
feat(jira-backend): export the 'callApi' function

### DIFF
--- a/.changeset/popular-pumpkins-play.md
+++ b/.changeset/popular-pumpkins-play.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+The `callApi` function is now exported to make it easy to use the `jira-dashboard-backend`
+configuration in any Backstage plugin.

--- a/plugins/jira-dashboard-backend/api-report.md
+++ b/plugins/jira-dashboard-backend/api-report.md
@@ -6,7 +6,16 @@
 import { BackendFeatureCompat } from '@backstage/backend-plugin-api';
 import { Filter } from '@axis-backstage/plugin-jira-dashboard-common';
 import { JiraQueryResults } from '@axis-backstage/plugin-jira-dashboard-common';
+import { RequestInit as RequestInit_2 } from 'node-fetch';
+import { Response as Response_2 } from 'node-fetch';
 import { RootConfigService } from '@backstage/backend-plugin-api';
+
+// @public
+export function callApi(
+  instance: ConfigInstance,
+  url: string,
+  init?: RequestInit_2,
+): Promise<Response_2>;
 
 // @public
 export type ConfigInstance = {

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -147,8 +147,10 @@ export async function getProjectAvatar(url: string, instance: ConfigInstance) {
  * Call the Jira API using fetch.
  *
  * This function injects the auth token and custom headers.
+ *
+ * @public
  */
-async function callApi(
+export async function callApi(
   instance: ConfigInstance,
   url: string,
   init?: RequestInit,

--- a/plugins/jira-dashboard-backend/src/index.ts
+++ b/plugins/jira-dashboard-backend/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { jiraDashboardPlugin as default } from './plugin';
-export { searchJira } from './api';
+export { searchJira, callApi } from './api';
 export type { SearchOptions } from './api';
 export type { ConfigInstance } from './config';
 export { JiraConfig } from './config';


### PR DESCRIPTION
The `callApi` function is now exported to make it easy to use the `jira-dashboard-backend`
configuration in any Backstage plugin.