### PR TITLE
Use annotationPrefix from app-config

### DIFF
--- a/.changeset/eighty-penguins-flow.md
+++ b/.changeset/eighty-penguins-flow.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/app': patch
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Fixed so JiraDashboard content can read config value from app-config file.

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -1,5 +1,7 @@
 export interface Config {
-  /** Configuration options for the Jira Dashboard plugin */
+  /**
+   * Configuration options for the Jira Dashboard plugin
+   */
   jiraDashboard:
     | {
         /**
@@ -28,6 +30,7 @@ export interface Config {
 
         /**
          * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * @visibility frontend
          */
         annotationPrefix?: string;
 
@@ -46,6 +49,7 @@ export interface Config {
     | {
         /**
          * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * @visibility frontend
          */
         annotationPrefix?: string;
 

--- a/plugins/jira-dashboard/api-report.md
+++ b/plugins/jira-dashboard/api-report.md
@@ -25,7 +25,6 @@ import { TableOptions } from '@backstage/core-components';
 export const EntityJiraDashboardContent: (
   props?:
     | {
-        annotationPrefix?: string | undefined;
         showFilters?: boolean | TableFilter[] | undefined;
       }
     | undefined,

--- a/plugins/jira-dashboard/config.d.ts
+++ b/plugins/jira-dashboard/config.d.ts
@@ -1,0 +1,20 @@
+export interface Config {
+  /**
+   * Configuration options for the Jira Dashboard plugin
+   */
+  jiraDashboard:
+    | {
+        /**
+         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * @visibility frontend
+         */
+        annotationPrefix?: string;
+      }
+    | {
+        /**
+         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * @visibility frontend
+         */
+        annotationPrefix?: string;
+      };
+}

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -82,23 +82,7 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist",
-    "config.d.ts"
+    "dist"
   ],
-  "configSchema": {
-    "$schema": "https://backstage.io/schema/config-v1",
-    "title": "@axis-backstage/plugin-jira-dashboard",
-    "type": "object",
-    "properties": {
-      "jiraDashboard": {
-        "type": "object",
-        "properties": {
-          "annotationPrefix": {
-            "type": "string",
-            "visibility": "frontend"
-          }
-        }
-      }
-    }
-  }
+  "configSchema": "config.d.ts"
 }

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -82,6 +82,23 @@
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": {
+    "$schema": "https://backstage.io/schema/config-v1",
+    "title": "@axis-backstage/plugin-jira-dashboard",
+    "type": "object",
+    "properties": {
+      "jiraDashboard": {
+        "type": "object",
+        "properties": {
+          "annotationPrefix": {
+            "type": "string",
+            "visibility": "frontend"
+          }
+        }
+      }
+    }
+  }
 }

--- a/plugins/jira-dashboard/src/alpha/entityContent.tsx
+++ b/plugins/jira-dashboard/src/alpha/entityContent.tsx
@@ -29,7 +29,7 @@ export const entityJiraContent = EntityContentBlueprint.makeWithOverrides({
       optional: true,
     }),
   },
-  factory: (originalFactory, { inputs }) => {
+  factory: originalFactory => {
     return originalFactory({
       defaultPath: '/jira',
       defaultTitle: 'Jira Dashboard',
@@ -37,13 +37,7 @@ export const entityJiraContent = EntityContentBlueprint.makeWithOverrides({
       routeRef: convertLegacyRouteRef(rootRouteRef),
       loader: async () =>
         import('../components/JiraDashboardContent').then(m =>
-          compatWrapper(
-            <m.JiraDashboardContent
-              annotationPrefix={inputs.props?.get(
-                annotationPrefixExtensionDataRef.optional(),
-              )}
-            />,
-          ),
+          compatWrapper(<m.JiraDashboardContent />),
         ),
     });
   },

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
@@ -4,6 +4,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import {
+  MockConfigApi,
   MockFetchApi,
   TestApiRegistry,
   renderInTestApp,
@@ -13,6 +14,7 @@ import { JiraDashboardClient, jiraDashboardApiRef } from '../../api';
 import { ApiProvider, UrlPatternDiscovery } from '@backstage/core-app-api';
 import mockedJiraResponse from '../../../dev/__fixtures__/jiraResponse.json';
 import mockedEntity from '../../../dev/__fixtures__/entity.json';
+import { configApiRef } from '@backstage/core-plugin-api';
 
 describe('JiraDashboardContent', () => {
   const server = setupServer();
@@ -85,14 +87,25 @@ describe('JiraDashboardContent', () => {
   });
 
   it('renders missing annotations screen if annotation is not present', async () => {
+    const mockConfigApi = new MockConfigApi({
+      jiraDashboard: {
+        annotationPrefix: 'different-jira',
+      },
+    });
+
+    const mockedConfigApis = TestApiRegistry.from(
+      [configApiRef, mockConfigApi],
+      [jiraDashboardApiRef, jiraClient],
+    );
+
     const rendered = await renderInTestApp(
       <EntityProvider entity={mockedEntity}>
-        <ApiProvider apis={apis}>
-          <JiraDashboardContent annotationPrefix="different-prefix" />,
+        <ApiProvider apis={mockedConfigApis}>
+          <JiraDashboardContent />,
         </ApiProvider>
       </EntityProvider>,
     );
     expect(rendered.getByText(/Missing Annotation/)).toBeInTheDocument();
-    expect(rendered.getAllByText(/different-prefix/).length).toBeGreaterThan(0);
+    expect(rendered.getAllByText(/different-jira/)).toHaveLength(2);
   });
 });

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -13,7 +13,7 @@ import Link from '@mui/material/Link';
 import React from 'react';
 import { JiraProjectCard } from '../JiraProjectCard';
 import { JiraTable } from '../JiraTable';
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   MissingAnnotationEmptyState,
   useEntity,
@@ -25,11 +25,15 @@ import { isJiraDashboardAvailable } from '../../plugin';
 import { JiraDataResponse } from '@axis-backstage/plugin-jira-dashboard-common';
 
 export const JiraDashboardContent = (props?: {
-  annotationPrefix?: string;
   showFilters?: TableFilter[] | boolean;
 }) => {
   const { entity } = useEntity();
   const api = useApi(jiraDashboardApiRef);
+  const config = useApi(configApiRef);
+  const annotationPrefix =
+    config
+      .getOptionalConfig('jiraDashboard')
+      ?.getOptionalString('annotationPrefix') || 'jira.com';
 
   const {
     data: jiraResponse,
@@ -40,12 +44,8 @@ export const JiraDashboardContent = (props?: {
   // In new frontend system, we can't yet conditionally render the tab content based on annotation key presence,
   // so add back in a check for the missing annotation here / render a nicer screen if it's missing. Will
   // still display the ResponseErrorPanel if the actual API call to jira fails.
-  if (!isJiraDashboardAvailable(entity, props?.annotationPrefix)) {
-    return (
-      <MissingAnnotationEmptyState
-        annotation={`${props?.annotationPrefix ?? 'jira.com'}`}
-      />
-    );
+  if (!isJiraDashboardAvailable(entity, annotationPrefix)) {
+    return <MissingAnnotationEmptyState annotation={annotationPrefix} />;
   }
 
   if (loading) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The JiraDashboardContent now uses the annotationPrefix from the app-config file. 

Changes:
- Made the annotationPrefix config value visible in frontend
- Added the configSchema to JiraDashboard package.json file according to https://backstage.io/docs/conf/defining/ 

Would like to remove the need of setting `if={entity => isJiraDashboardAvailable(entity, 'jira')}` at all in frontend, but will try to fix that in future PR.

### Context

Using an alternative Jira annotation instead of 'jira.com' didn't work because JiraDashboardContent couldn't read the custom config annotationPrefix value, defaulting back to 'jira.com'. This has now been fixed.

### Issue ticket number and link

- Fixes #227 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
