### PR TITLE
Issue 240 - ability to add filter to JiraUserIssuesViewCard

### DIFF
--- a/.changeset/serious-pumas-kiss.md
+++ b/.changeset/serious-pumas-kiss.md
@@ -1,0 +1,6 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Adds ability to use an optional provided Jira filter defined in app-config for JiraUserIssuesViewCard

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -249,12 +249,15 @@ export async function createRouter(
         request.query.maxResults || DEFAULT_MAX_RESULTS_USER_ISSUES,
       );
 
+      const filterName = (request.query?.filterName as string) || 'default';
+
       try {
         const issues = await getUserIssues(
           username,
           maxResults,
           instance,
           cache,
+          filterName,
         );
         return { issues, error: undefined };
       } catch (error: any) {

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -76,8 +76,16 @@ export const getUserIssues = async (
   maxResults: number,
   config: ConfigInstance,
   cache: CacheService,
+  filterName: string,
 ): Promise<Issue[]> => {
-  const jql = `assignee = "${username}" AND resolution = Unresolved ORDER BY priority DESC, updated DESC`;
+  let jql = `assignee = "${username}" AND resolution = Unresolved ORDER BY priority DESC, updated DESC`;
+  if (filterName !== 'default') {
+    for (const filter of config.defaultFilters || []) {
+      if (filterName === filter.name) {
+        jql = `assignee = "${username}" AND ${filter.query}`;
+      }
+    }
+  }
 
   return getJqlResponse(jql, config, cache, {
     fields: [

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -113,6 +113,39 @@ import { JiraUserIssuesViewCard } from '@axis-backstage/plugin-jira-dashboard';
 // ...
 ```
 
+You can also optionally supply a filterName property that corresponds to a filter defined in the [defaultFilters](https://github.com/AxisCommunications/backstage-plugins/tree/main/plugins/jira-dashboard-backend#configuration-1) section of the app-config.yaml file for this particular Jira instance. Example:
+
+```tsx
+import { JiraUserIssuesViewCard } from '@axis-backstage/plugin-jira-dashboard';
+// ...
+
+<Grid item xs={12} md={6}>
+  <JiraUserIssuesViewCard
+    bottomLinkProps={{
+      link: 'https://our-jira-server/issues',
+      title: 'Open in Jira',
+    }}
+    maxResults={30} // default is 15
+    filterName="Unresolved"
+  />
+</Grid>;
+
+// ...
+```
+
+```yaml
+jiraDashboard:
+  annotationPrefix: jira
+  instances:
+    - name: default
+      token: ...
+      baseUrl: https://<team>.atlassian.net/rest/api/3/
+      defaultFilters:
+        - name: 'Unresolved'
+          shortName: 'Unresolved'
+          query: 'status != Done AND status != Decline ORDER BY updated DESC, priority DESC'
+```
+
 Note that the list of user issues is limited by permissions defined for the [JIRA_TOKEN](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard-backend/README.md#configuration-details) used by backend.
 The username is being extracted from the user's email or created as a combination of user entity `metadata.name` and [JIRA_EMAIL_SUFFIX](https://github.com/AxisCommunications/backstage-plugins/blob/main/plugins/jira-dashboard-backend/README.md#configuration-details) ([see function `getAssigneUser`](/plugins/jira-dashboard-backend/src/filters.ts) for more information).
 

--- a/plugins/jira-dashboard/api-report.md
+++ b/plugins/jira-dashboard/api-report.md
@@ -39,7 +39,10 @@ export const isJiraDashboardAvailable: (
 // @public
 export type JiraDashboardApi = {
   getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
-  getLoggedInUserIssues(maxResults: number): Promise<Issue[]>;
+  getLoggedInUserIssues(
+    maxResults: number,
+    filterName: string,
+  ): Promise<Issue[]>;
   getProjectAvatar(entityRef: string): any;
 };
 
@@ -50,7 +53,10 @@ export const jiraDashboardApiRef: ApiRef<JiraDashboardApi>;
 export class JiraDashboardClient implements JiraDashboardApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
   getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
-  getLoggedInUserIssues(maxResults: number): Promise<Issue[]>;
+  getLoggedInUserIssues(
+    maxResults: number,
+    filterName: string,
+  ): Promise<Issue[]>;
   getProjectAvatar(entityRef: string): Promise<string>;
 }
 
@@ -70,6 +76,7 @@ export type JiraUserIssuesCardProps = {
   bottomLinkProps?: BottomLinkProps;
   tableOptions?: TableOptions<Issue>;
   tableStyle?: TableComponentProps['style'];
+  filterName?: string;
 };
 
 // @public
@@ -79,6 +86,7 @@ export const JiraUserIssuesTable: ({
   tableStyle,
   style,
   tableOptions,
+  filterName,
 }: JiraUserIssuesTableProps) => JSX_2.Element | null;
 
 // @public
@@ -88,6 +96,7 @@ export type JiraUserIssuesTableProps = {
   tableStyle?: TableComponentProps['style'];
   style?: CSSProperties;
   tableOptions?: TableOptions<Issue>;
+  filterName?: string;
 };
 
 // @public
@@ -97,6 +106,7 @@ export const JiraUserIssuesViewCard: ({
   bottomLinkProps,
   tableOptions,
   tableStyle,
+  filterName,
 }: JiraUserIssuesCardProps) => JSX_2.Element;
 
 // @public
@@ -115,6 +125,7 @@ export function useJira(
 // @public
 export function useJiraUserIssues(
   maxResults: number,
+  filterName: string,
   jiraDashboardApi: JiraDashboardApi,
 ): {
   data: Issue[] | undefined;

--- a/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardApi.tsx
@@ -19,6 +19,9 @@ export const jiraDashboardApiRef = createApiRef<JiraDashboardApi>({
  */
 export type JiraDashboardApi = {
   getJiraResponseByEntity(entityRef: string): Promise<JiraResponse>;
-  getLoggedInUserIssues(maxResults: number): Promise<Issue[]>;
+  getLoggedInUserIssues(
+    maxResults: number,
+    filterName: string,
+  ): Promise<Issue[]>;
   getProjectAvatar(entityRef: string): any;
 };

--- a/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
+++ b/plugins/jira-dashboard/src/api/JiraDashboardClient.tsx
@@ -56,12 +56,16 @@ export class JiraDashboardClient implements JiraDashboardApi {
   /**
    * Get the Jira issues for the calling user.
    */
-  async getLoggedInUserIssues(maxResults: number): Promise<Issue[]> {
+  async getLoggedInUserIssues(
+    maxResults: number,
+    filterName: string,
+  ): Promise<Issue[]> {
     const apiUrl = await this.discoveryApi.getBaseUrl('jira-dashboard');
 
     // Convert to query parameters
     const searchParams = new URLSearchParams({
       maxResults: maxResults.toString(),
+      filterName: filterName,
     });
 
     const resp = await this.fetchApi.fetch(

--- a/plugins/jira-dashboard/src/components/JiraUserIssuesCard/JiraUserIssuesCard.tsx
+++ b/plugins/jira-dashboard/src/components/JiraUserIssuesCard/JiraUserIssuesCard.tsx
@@ -22,6 +22,7 @@ export type JiraUserIssuesCardProps = {
   bottomLinkProps?: BottomLinkProps;
   tableOptions?: TableOptions<Issue>;
   tableStyle?: TableComponentProps['style'];
+  filterName?: string;
 };
 
 /**
@@ -42,6 +43,7 @@ export const JiraUserIssuesCard = ({
     overflowY: 'auto',
     width: '100%',
   },
+  filterName,
 }: JiraUserIssuesCardProps) => {
   return (
     <InfoCard title={title} variant="fullHeight" deepLink={bottomLinkProps}>
@@ -49,6 +51,7 @@ export const JiraUserIssuesCard = ({
         maxResults={maxResults}
         tableOptions={tableOptions}
         tableStyle={tableStyle}
+        filterName={filterName}
       />
     </InfoCard>
   );

--- a/plugins/jira-dashboard/src/components/JiraUserIssuesTable/JiraUserIssuesTable.tsx
+++ b/plugins/jira-dashboard/src/components/JiraUserIssuesTable/JiraUserIssuesTable.tsx
@@ -36,6 +36,7 @@ export type JiraUserIssuesTableProps = {
   tableStyle?: TableComponentProps['style'];
   style?: CSSProperties;
   tableOptions?: TableOptions<Issue>;
+  filterName?: string;
 };
 
 const userColumns: TableColumn<Issue>[] = [
@@ -55,6 +56,7 @@ export const JiraUserIssuesTable = ({
   tableStyle,
   style,
   tableOptions,
+  filterName = 'default',
 }: JiraUserIssuesTableProps) => {
   const api = useApi(jiraDashboardApiRef);
 
@@ -62,7 +64,7 @@ export const JiraUserIssuesTable = ({
     data: jiraResponse,
     loading,
     error,
-  } = useJiraUserIssues(maxResults, api);
+  } = useJiraUserIssues(maxResults, filterName, api);
 
   if (loading) {
     return <Progress />;

--- a/plugins/jira-dashboard/src/hooks/useJiraUserIssues.ts
+++ b/plugins/jira-dashboard/src/hooks/useJiraUserIssues.ts
@@ -5,11 +5,13 @@ import { Issue } from '@axis-backstage/plugin-jira-dashboard-common';
 /**
  * Hook to get the issues of the logged in user.
  * @param maxResults - The maximum number of issues to return
+ * @param filterName - Filter name from provided list of default filters
  * @param jiraDashboardApi - The Jira dashboard API
  * @public
  */
 export function useJiraUserIssues(
   maxResults: number,
+  filterName: string,
   jiraDashboardApi: JiraDashboardApi,
 ): {
   data: Issue[] | undefined;
@@ -21,7 +23,7 @@ export function useJiraUserIssues(
     loading,
     error,
   } = useAsync(async () => {
-    return jiraDashboardApi.getLoggedInUserIssues(maxResults);
+    return jiraDashboardApi.getLoggedInUserIssues(maxResults, filterName);
   }, [jiraDashboardApi]);
   return { data, loading, error };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the ability to use a filter provided in the `defaultFilters` config in the app-config.yaml file in the API call used for the JiraUserIssuesViewCard.

### Context

Custom Jira filters were able to be used in Entity pages, but not in the custom homepage component. This MR adds in that ability.

### Issue ticket number and link

- Fixes #240 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
