### PR TITLE
Quote project key in JQL query and provide failure printing. 

### DIFF
--- a/.changeset/strong-sheep-live.md
+++ b/.changeset/strong-sheep-live.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+---
+
+Qoute project key to avoid JQL keyword usage; provide error message for jql failure

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -58,7 +58,7 @@ export const getIssuesByFilter = async (
   const issues: Issue[] = [];
   for (const project of projects) {
     const { projectKey, instance } = project;
-    const jql = jqlQueryBuilder({ project: [projectKey], components, query });
+    const jql = jqlQueryBuilder({ project: ["\""+projectKey+"\""], components, query });
     const response = await callApi(
       instance,
       `${instance.baseUrl}search?jql=${jql}`,

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -59,7 +59,7 @@ export const getIssuesByFilter = async (
   for (const project of projects) {
     const { projectKey, instance } = project;
     const jql = jqlQueryBuilder({
-      project: ['"' + projectKey + '"'],
+      project: [`"${projectKey}\"`],
       components,
       query,
     });

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -58,7 +58,11 @@ export const getIssuesByFilter = async (
   const issues: Issue[] = [];
   for (const project of projects) {
     const { projectKey, instance } = project;
-    const jql = jqlQueryBuilder({ project: ["\""+projectKey+"\""], components, query });
+    const jql = jqlQueryBuilder({
+      project: ['"' + projectKey + '"'],
+      components,
+      query,
+    });
     const response = await callApi(
       instance,
       `${instance.baseUrl}search?jql=${jql}`,
@@ -71,9 +75,9 @@ export const getIssuesByFilter = async (
     )
       .then(resp => resp.json())
       .catch(() => null);
-    if (response?.errorMessages){
+    if (response?.errorMessages) {
       throw Error(
-        `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages[0]}`
+        `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages[0]}`,
       );
     }
     if (response?.issues) {

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -59,7 +59,7 @@ export const getIssuesByFilter = async (
   for (const project of projects) {
     const { projectKey, instance } = project;
     const jql = jqlQueryBuilder({
-      project: [`"${projectKey}\"`],
+      project: [`"${projectKey}"`],
       components,
       query,
     });

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -59,7 +59,7 @@ export const getIssuesByFilter = async (
   for (const project of projects) {
     const { projectKey, instance } = project;
     const jql = jqlQueryBuilder({
-      project: [`"${projectKey}"`],
+      project: [projectKey],
       components,
       query,
     });

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -71,7 +71,11 @@ export const getIssuesByFilter = async (
     )
       .then(resp => resp.json())
       .catch(() => null);
-
+    if (response?.errorMessages){
+      throw Error(
+        `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages[0]}`
+      );
+    }
     if (response?.issues) {
       issues.push(...response.issues);
     }

--- a/plugins/jira-dashboard-backend/src/queries.ts
+++ b/plugins/jira-dashboard-backend/src/queries.ts
@@ -19,7 +19,7 @@ export const jqlQueryBuilder = ({
   query,
 }: JqlQueryBuilderArgs) => {
   const projectList = Array.isArray(project) ? project : [project];
-  let jql = `project in (${projectList.join(',')})`;
+  let jql = `project in ("${projectList.join('","')}")`;
   if (components && components.length > 0) {
     let componentsInclude = '(';
     for (let index = 0; index < components.length; index++) {


### PR DESCRIPTION
### Context

Due to how JIRA project naming works, it will allow project keys with JQL reserved keywords. When used without quotes, the JQL will fail and throw an error message that you must quote them. Since quoting the project key has no downside, doing so will ensure compatibility regardless of project key. 

### Issue ticket number and link

- Fixes #253 

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
