### PR TITLE
Readme backend: Make the fileNames lookup configurable

### DIFF
--- a/.changeset/rotten-pugs-talk.md
+++ b/.changeset/rotten-pugs-talk.md
@@ -1,0 +1,14 @@
+---
+'@axis-backstage/plugin-readme-backend': minor
+---
+
+A configuration has been added to the readme backend that makes it possible to
+configure which files to look for and the exact order. Example:
+
+```yaml
+readme:
+  -fileNames:
+    - README.txt
+    - README.text
+    - README.markdown
+```

--- a/plugins/readme-backend/config.d.ts
+++ b/plugins/readme-backend/config.d.ts
@@ -1,0 +1,12 @@
+export interface Config {
+  /**
+   * Configuration options for the Readme backend plugin
+   */
+  readme?: {
+    /**
+     * Optional list of file names to try. Specifies the file names to try
+     * when looking for a README file and which order to use.
+     */
+    fileNames?: string[];
+  };
+}

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -32,7 +32,6 @@
     "@backstage/backend-plugin-api": "^1.2.0",
     "@backstage/catalog-client": "^1.9.1",
     "@backstage/catalog-model": "^1.7.3",
-    "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.16.1",
     "@types/express": "*",
@@ -42,11 +41,14 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.3.0",
     "@backstage/cli": "^0.30.0",
+    "@backstage/config": "^1.3.2",
     "@types/supertest": "^2.0.12",
     "msw": "^2.7.3",
     "supertest": "^6.2.4"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -32,6 +32,7 @@
     "@backstage/backend-plugin-api": "^1.2.0",
     "@backstage/catalog-client": "^1.9.1",
     "@backstage/catalog-model": "^1.7.3",
+    "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.16.1",
     "@types/express": "*",

--- a/plugins/readme-backend/src/service/constants.test.ts
+++ b/plugins/readme-backend/src/service/constants.test.ts
@@ -1,0 +1,38 @@
+import { ConfigReader } from '@backstage/config';
+import { NOT_FOUND_PLACEHOLDER, getReadmeTypes } from './constants';
+
+describe('constants', () => {
+  describe('NOT_FOUND_PLACEHOLDER', () => {
+    it('should be defined', () => {
+      expect(NOT_FOUND_PLACEHOLDER).toBeDefined();
+      expect(NOT_FOUND_PLACEHOLDER).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('getReadmeTypes', () => {
+    it('should return default readme types when config is empty', () => {
+      const config = new ConfigReader({});
+      const readmeTypes = getReadmeTypes(config);
+      expect(readmeTypes).toEqual([
+        { name: 'README.md', type: 'text/markdown' },
+        { name: 'README.MD', type: 'text/markdown' },
+        { name: 'README', type: 'text/plain' },
+        { name: 'README.rst', type: 'text/plain' },
+        { name: 'README.txt', type: 'text/plain' },
+      ]);
+    });
+
+    it('should return custom readme types from config', () => {
+      const config = new ConfigReader({
+        readme: {
+          fileNames: ['CUSTOM.md', 'CUSTOM.txt'],
+        },
+      });
+      const readmeTypes = getReadmeTypes(config);
+      expect(readmeTypes).toEqual([
+        { name: 'CUSTOM.md', type: 'text/markdown' },
+        { name: 'CUSTOM.txt', type: 'text/plain' },
+      ]);
+    });
+  });
+});

--- a/plugins/readme-backend/src/service/constants.ts
+++ b/plugins/readme-backend/src/service/constants.ts
@@ -4,9 +4,9 @@ import { FileType } from './types';
 export const NOT_FOUND_PLACEHOLDER = 'NOT_FOUND';
 
 export const README_TYPES: FileType[] = [
-  { name: 'README', type: 'text/plain' },
   { name: 'README.md', type: 'text/markdown' },
+  { name: 'README.MD', type: 'text/markdown' },
+  { name: 'README', type: 'text/plain' },
   { name: 'README.rst', type: 'text/plain' },
   { name: 'README.txt', type: 'text/plain' },
-  { name: 'README.MD', type: 'text/markdown' },
 ];

--- a/plugins/readme-backend/src/service/constants.ts
+++ b/plugins/readme-backend/src/service/constants.ts
@@ -18,7 +18,10 @@ export function getReadmeTypes(config: Config): FileType[] {
     return DEFAULT_README_TYPES;
   }
   return readmeTypes.map(name => {
-    const type = name.endsWith('.md') || name.endsWith('.MD') ? 'text/markdown' : 'text/plain';
+    const type =
+      name.endsWith('.md') || name.endsWith('.MD')
+        ? 'text/markdown'
+        : 'text/plain';
     return { name, type };
   });
 }

--- a/plugins/readme-backend/src/service/constants.ts
+++ b/plugins/readme-backend/src/service/constants.ts
@@ -1,5 +1,7 @@
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { FileType } from './types';
-import { Config } from '@backstage/config';
+
+const CONFIG_PATH = 'readme.fileNames';
 
 // Cache placeholder for entities where no readme
 export const NOT_FOUND_PLACEHOLDER = 'NOT_FOUND';
@@ -12,8 +14,8 @@ const DEFAULT_README_TYPES: FileType[] = [
   { name: 'README.txt', type: 'text/plain' },
 ];
 
-export function getReadmeTypes(config: Config): FileType[] {
-  const readmeTypes = config.getOptionalStringArray('readme.types');
+export function getReadmeTypes(config: RootConfigService): FileType[] {
+  const readmeTypes = config.getOptionalStringArray(CONFIG_PATH);
   if (!readmeTypes) {
     return DEFAULT_README_TYPES;
   }

--- a/plugins/readme-backend/src/service/constants.ts
+++ b/plugins/readme-backend/src/service/constants.ts
@@ -1,12 +1,24 @@
 import { FileType } from './types';
+import { Config } from '@backstage/config';
 
 // Cache placeholder for entities where no readme
 export const NOT_FOUND_PLACEHOLDER = 'NOT_FOUND';
 
-export const README_TYPES: FileType[] = [
+const DEFAULT_README_TYPES: FileType[] = [
   { name: 'README.md', type: 'text/markdown' },
   { name: 'README.MD', type: 'text/markdown' },
   { name: 'README', type: 'text/plain' },
   { name: 'README.rst', type: 'text/plain' },
   { name: 'README.txt', type: 'text/plain' },
 ];
+
+export function getReadmeTypes(config: Config): FileType[] {
+  const readmeTypes = config.getOptionalStringArray('readme.types');
+  if (!readmeTypes) {
+    return DEFAULT_README_TYPES;
+  }
+  return readmeTypes.map(name => {
+    const type = name.endsWith('.md') || name.endsWith('.MD') ? 'text/markdown' : 'text/plain';
+    return { name, type };
+  });
+}

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -17,16 +17,7 @@ import { isError, NotFoundError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
 import { isSymLink } from '../lib';
-<<<<<<< HEAD
 import { NOT_FOUND_PLACEHOLDER, getReadmeTypes } from './constants';
-
-=======
-import {
-  DEFAULT_TTL,
-  NOT_FOUND_PLACEHOLDER,
-  getReadmeTypes,
-} from './constants';
->>>>>>> 3601a22c (Format code for better readability in constants and router files)
 import { ReadmeFile } from './types';
 
 /**

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -17,7 +17,8 @@ import { isError, NotFoundError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
 import { isSymLink } from '../lib';
-import { NOT_FOUND_PLACEHOLDER, README_TYPES } from './constants';
+import { NOT_FOUND_PLACEHOLDER, getReadmeTypes } from './constants';
+
 import { ReadmeFile } from './types';
 
 /**
@@ -95,7 +96,9 @@ export async function createRouter(
       return;
     }
 
-    for (const fileType of README_TYPES) {
+    const readmeTypes = getReadmeTypes(config);
+
+    for (const fileType of readmeTypes) {
       const url = integration.resolveUrl({
         url: fileType.name,
         base: source.target,

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -17,8 +17,16 @@ import { isError, NotFoundError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
 import { isSymLink } from '../lib';
+<<<<<<< HEAD
 import { NOT_FOUND_PLACEHOLDER, getReadmeTypes } from './constants';
 
+=======
+import {
+  DEFAULT_TTL,
+  NOT_FOUND_PLACEHOLDER,
+  getReadmeTypes,
+} from './constants';
+>>>>>>> 3601a22c (Format code for better readability in constants and router files)
 import { ReadmeFile } from './types';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,6 +1548,7 @@ __metadata:
     "@backstage/catalog-client": "npm:^1.9.1"
     "@backstage/catalog-model": "npm:^1.7.3"
     "@backstage/cli": "npm:^0.30.0"
+    "@backstage/config": "npm:^1.3.2"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/integration": "npm:^1.16.1"
     "@types/express": "npm:*"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A configuration has been added to the readme backend that makes it possible to
configure which files to look for and the exact order. This is an update on PR #256.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info]
