### PR TITLE
feat(jira-backend): escape the projects in the jql string

### DIFF
--- a/.changeset/old-coins-lick.md
+++ b/.changeset/old-coins-lick.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Each project key in the JQL query are now wrapped in single qoutes to handle projects that contains reserved JQL words.

--- a/plugins/jira-dashboard-backend/src/api.test.ts
+++ b/plugins/jira-dashboard-backend/src/api.test.ts
@@ -65,7 +65,7 @@ describe('api', () => {
     const issues = await getIssuesByComponent(projects, 'ccc');
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://jira.com/search?jql=project in (ppp,bbb) AND component in ('ccc')",
+      "http://jira.com/search?jql=project in ('ppp','bbb') AND component in ('ccc')",
       {
         method: 'GET',
         headers: {
@@ -96,7 +96,7 @@ describe('api', () => {
     const issues = await getIssuesByComponent(projects, 'ccc');
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://jira.com/search?jql=project in (ppp) AND component in ('ccc')",
+      "http://jira.com/search?jql=project in ('ppp') AND component in ('ccc')",
       {
         method: 'GET',
         headers: {
@@ -124,7 +124,7 @@ describe('api', () => {
     const issues = await getIssuesByComponent(projects, 'ccc,ddd');
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://jira.com/search?jql=project in (ppp,bbb) AND component in ('ccc','ddd')",
+      "http://jira.com/search?jql=project in ('ppp','bbb') AND component in ('ccc','ddd')",
       {
         method: 'GET',
         headers: {
@@ -162,7 +162,7 @@ describe('api', () => {
     const issues = await getIssuesByComponent(projects, 'ccc');
 
     expect(fetch).toHaveBeenCalledWith(
-      "http://jira.com/search?jql=project in (invalid) AND component in ('ccc')",
+      "http://jira.com/search?jql=project in ('invalid') AND component in ('ccc')",
       {
         method: 'GET',
         headers: {

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -71,7 +71,11 @@ export const getIssuesByFilter = async (
     )
       .then(resp => resp.json())
       .catch(() => null);
-
+    if (response?.errorMessages) {
+      throw Error(
+        `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages?.[0]}`,
+      );
+    }
     if (response?.issues) {
       issues.push(...response.issues);
     }
@@ -135,13 +139,16 @@ export const getIssuesByComponent = async (
     return [];
   }
 
-  const projectKeys = projects.map(project => project.projectKey).join(',');
+  const projectKeys = projects.map(project => project.projectKey);
   const components = componentKeys
     .split(',')
-    .map(component => `'${component.trim()}'`)
-    .join(',');
+    .map(component => component.trim());
 
-  const jql = `project in (${projectKeys}) AND component in (${components})`;
+  const jql = jqlQueryBuilder({
+    project: projectKeys,
+    components,
+  });
+
   const { instance } = projects[0];
 
   try {

--- a/plugins/jira-dashboard-backend/src/queries.test.ts
+++ b/plugins/jira-dashboard-backend/src/queries.test.ts
@@ -1,20 +1,53 @@
-import { jqlQueryBuilder } from './queries';
+import { createEscapedIncludeQuery, jqlQueryBuilder } from './queries';
 
 describe('queries', () => {
-  it('can use all arguments build a query.', async () => {
-    const jql = jqlQueryBuilder({
-      project: 'BS,SB',
-      components: ['comp 1', 'comp 2'],
-      query: 'filter=example',
+  describe('jqlQueryBuilder', () => {
+    it('can use all arguments build a query.', async () => {
+      const jql = jqlQueryBuilder({
+        project: ['BS', 'SB'],
+        components: ['comp 1', 'comp 2'],
+        query: 'filter=example',
+      });
+      expect(jql).toBe(
+        "project in ('BS','SB') AND component in ('comp 1','comp 2') AND filter=example",
+      );
     });
-    expect(jql).toBe(
-      "project in (BS,SB) AND component in ('comp 1','comp 2') AND filter=example",
-    );
+
+    it('can create a query using only a project as argument.', async () => {
+      const jql = jqlQueryBuilder({
+        project: ['BS'],
+      });
+      expect(jql).toBe("project in ('BS')");
+    });
+
+    it('can create a query with multiple projects and no components or additional query.', async () => {
+      const jql = jqlQueryBuilder({
+        project: ['BS', 'SB'],
+      });
+      expect(jql).toBe("project in ('BS','SB')");
+    });
+
+    it('can create a query with an additional query but no components.', async () => {
+      const jql = jqlQueryBuilder({
+        project: ['BS'],
+        query: 'filter=example',
+      });
+      expect(jql).toBe("project in ('BS') AND filter=example");
+    });
   });
-  it('can create a query using only a project as argument.', async () => {
-    const jql = jqlQueryBuilder({
-      project: 'BS',
+
+  describe('createEscapedIncludeQuery', () => {
+    it('creates a query with a single value', () => {
+      const query = createEscapedIncludeQuery('affectedVersion', ['3.14']);
+      expect(query).toBe("affectedVersion in ('3.14')");
     });
-    expect(jql).toBe('project in (BS)');
+
+    it('creates a query with multiple values', () => {
+      const query = createEscapedIncludeQuery('affectedVersion', [
+        '3.14',
+        '4.2',
+      ]);
+      expect(query).toBe("affectedVersion in ('3.14','4.2')");
+    });
   });
 });

--- a/plugins/jira-dashboard-backend/src/queries.ts
+++ b/plugins/jira-dashboard-backend/src/queries.ts
@@ -10,7 +10,33 @@ export type JqlQueryBuilderArgs = {
 };
 
 /**
- * Creates a jql query string.
+ *  Creates a partial jql query string using the "in" operator to
+ *  include multiple values for a field.
+ *
+ *  Example:
+ *    "affectedVersion in ('3.14', '4.2')"
+ *
+ * @param field
+ * @param values
+ */
+export const createEscapedIncludeQuery = (field: string, values: string[]) => {
+  let query = `${field} in (`;
+  for (let index = 0; index < values.length; index++) {
+    const value = values[index];
+    query += `'${value}'`;
+    // Add either the "," separator or close the parentheses.
+    if (index === values.length - 1) {
+      query += ')';
+    } else {
+      query += ',';
+    }
+  }
+  return query;
+};
+
+/**
+ * Builds a JQL (Jira Query Language) query string based on the provided arguments.
+ *
  * @public
  */
 export const jqlQueryBuilder = ({
@@ -19,20 +45,9 @@ export const jqlQueryBuilder = ({
   query,
 }: JqlQueryBuilderArgs) => {
   const projectList = Array.isArray(project) ? project : [project];
-  let jql = `project in (${projectList.join(',')})`;
-  if (components && components.length > 0) {
-    let componentsInclude = '(';
-    for (let index = 0; index < components.length; index++) {
-      const component = components[index];
-      componentsInclude += `'${component}'`;
-      // Add either the "," separator or close the parentheses.
-      if (index === components.length - 1) {
-        componentsInclude += ')';
-      } else {
-        componentsInclude += ',';
-      }
-    }
-    jql += ` AND component in ${componentsInclude}`;
+  let jql = createEscapedIncludeQuery('project', projectList);
+  if (components?.length) {
+    jql += ` AND ${createEscapedIncludeQuery('component', components)}`;
   }
   if (query) {
     jql += ` AND ${query}`;


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Each project key in the JQL query are now wrapped in single qoutes to handle projects that contains reserved JQL words.

### Context

Please provide some context about the why this change is being made and what problem it aims to solve.

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
