### PR TITLE
chore(ci): set NODE_AUTH_TOKEN in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,5 @@ jobs:
           publish: yarn publish:github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Sets the NODE_AUTH_TOKEN env for the changeset action.
