### PR TITLE
Support Multiple Jira Project Cards in Tabbed View

### DIFF
--- a/.changeset/two-wings-kneel.md
+++ b/.changeset/two-wings-kneel.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Support Multiple Jira Project Cards in Tabbed View

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -133,15 +133,17 @@ export async function createRouter(
       const projects = fullProjectKeys.map(fullProjectKey =>
         splitProjectKey(config, fullProjectKey),
       );
+      const projectResponses: Project[] = [];
 
-      let projectResponse;
-
-      try {
-        projectResponse = await getProjectResponse(projects[0], cache);
-      } catch (err: any) {
-        logger.error(
-          `Could not find Jira project ${projects[0].fullProjectKey}: ${err.message}`,
-        );
+      for (const project of projects) {
+        try {
+          const projectData = await getProjectResponse(project, cache);
+          projectResponses.push(projectData);
+        } catch (err: any) {
+          logger.error(
+            `Could not find Jira project ${project.fullProjectKey}: ${err.message}`,
+          );
+        }
         response.status(404).json({
           error: `No Jira project found with key ${projects[0].projectKey}`,
         });
@@ -215,9 +217,10 @@ export async function createRouter(
       }
 
       const jiraResponse: JiraResponse = {
-        project: projectResponse as Project,
+        project: projectResponses,
         data: issues,
       };
+
       response.json(jiraResponse);
     },
   );

--- a/plugins/jira-dashboard-common/report.api.md
+++ b/plugins/jira-dashboard-common/report.api.md
@@ -72,7 +72,7 @@ export type JiraQueryResults = {
 
 // @public
 export type JiraResponse = {
-  project: Project;
+  project: Project | Project[];
   data: JiraDataResponse[];
 };
 

--- a/plugins/jira-dashboard-common/src/types.ts
+++ b/plugins/jira-dashboard-common/src/types.ts
@@ -75,7 +75,7 @@ export type Project = {
  *  @public
  */
 export type JiraResponse = {
-  project: Project;
+  project: Project | Project[];
   data: JiraDataResponse[];
 };
 

--- a/plugins/jira-dashboard/dev/__fixtures__/singleProjectResponse.json
+++ b/plugins/jira-dashboard/dev/__fixtures__/singleProjectResponse.json
@@ -1,40 +1,21 @@
 {
-  "project": [
-    {
-      "name": "Backstage",
-      "key": "BS",
-      "description": "This is our Backstage project",
-      "avatarUrls": {
-        "48x48": "https://api.dicebear.com/6.x/open-peeps/svg?seed=Duane"
-      },
-      "projectTypeKey": "Software",
-      "projectCategory": {
-        "name": "Software Portals"
-      },
-      "lead": {
-        "key": "fridaja",
-        "displayName": "Frida Jacobsson"
-      },
-      "self": "https://jira.com/project/123"
+  "project": {
+    "name": "Backstage",
+    "key": "BS",
+    "description": "This is our Backstage project",
+    "avatarUrls": {
+      "48x48": "https://api.dicebear.com/6.x/open-peeps/svg?seed=Duane"
     },
-    {
-      "name": "Backstage1",
-      "key": "BM",
-      "description": "This is our Backstage project",
-      "avatarUrls": {
-        "48x48": "https://api.dicebear.com/6.x/open-peeps/svg?seed=Duane"
-      },
-      "projectTypeKey": "Software test",
-      "projectCategory": {
-        "name": "Software Portals test"
-      },
-      "lead": {
-        "key": "fridaja",
-        "displayName": "Frida Jacobsson"
-      },
-      "self": "https://jira.com/project/456"
-    }
-  ],
+    "projectTypeKey": "Software",
+    "projectCategory": {
+      "name": "Software Portals"
+    },
+    "lead": {
+      "key": "fridaja",
+      "displayName": "Frida Jacobsson"
+    },
+    "self": "https://jira.com/project/123"
+  },
   "data": [
     {
       "name": "Open Issues",
@@ -64,7 +45,7 @@
         },
         {
           "key": "BS-2",
-          "self": "https://jira.com/project/456",
+          "self": "https://jira.com/project/123",
           "fields": {
             "summary": "Something is not working",
             "status": {
@@ -133,7 +114,7 @@
           }
         },
         {
-          "key": "BM-2",
+          "key": "BS-2",
           "self": "https://jira.com/project/123",
           "fields": {
             "summary": "Something is not working",

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -6,6 +6,8 @@ import {
   SupportButton,
   TableFilter,
   TableOptions,
+  TabbedCard,
+  CardTab,
 } from '@backstage/core-components';
 import Grid from '@mui/material/Unstable_Grid2';
 import Box from '@mui/material/Box';
@@ -41,7 +43,7 @@ export const JiraDashboardContent = (props?: {
     return <Progress />;
   } else if (error) {
     return <ResponseErrorPanel error={error} />;
-  } else if (!jiraResponse || !jiraResponse.data || !jiraResponse.project) {
+  } else if (!jiraResponse || !jiraResponse?.data || !jiraResponse?.project) {
     return (
       <ResponseErrorPanel
         error={Error(
@@ -50,6 +52,9 @@ export const JiraDashboardContent = (props?: {
       />
     );
   }
+  const projects = Array.isArray(jiraResponse.project)
+    ? jiraResponse.project
+    : [];
 
   return (
     <Content>
@@ -70,32 +75,64 @@ export const JiraDashboardContent = (props?: {
           </Box>
         </SupportButton>
       </ContentHeader>
-      <Grid container spacing={3}>
-        {jiraResponse && jiraResponse.data && (
-          <>
-            <Grid md={6} xs={12} data-testid="project-card">
-              <JiraProjectCard project={jiraResponse.project} />
-            </Grid>
-            {jiraResponse.data.map((value: JiraDataResponse) => (
-              <Grid data-testid="issue-table" key={value.name} md={6} xs={12}>
-                <JiraTable
-                  tableContent={value}
-                  showFilters={props?.showFilters}
-                  project={jiraResponse.project}
-                  tableOptions={props?.tableOptions}
-                  tableStyle={{
-                    height: 'max-content',
-                    maxHeight: '500px',
-                    padding: '20px',
-                    overflowY: 'auto',
-                    width: '100%',
-                  }}
-                />
+      {projects.length > 1 ? (
+        <TabbedCard title="Jira Projects" data-testid="tabbed-card">
+          {projects.map(project => (
+            <CardTab key={project.key} label={project.name}>
+              <Grid container spacing={3}>
+                <Grid md={6} xs={12} data-testid="project-card">
+                  <JiraProjectCard project={project} />
+                </Grid>
+                {jiraResponse.data.map(value => (
+                  <Grid
+                    data-testid="issue-table"
+                    key={value.name}
+                    md={6}
+                    xs={12}
+                  >
+                    <JiraTable
+                      tableContent={value}
+                      showFilters={props?.showFilters}
+                      project={project}
+                      tableOptions={props?.tableOptions}
+                      tableStyle={{
+                        height: 'max-content',
+                        maxHeight: '500px',
+                        padding: '20px',
+                        overflowY: 'auto',
+                        width: '100%',
+                      }}
+                    />
+                  </Grid>
+                ))}
               </Grid>
-            ))}
-          </>
-        )}
-      </Grid>
+            </CardTab>
+          ))}
+        </TabbedCard>
+      ) : (
+        <Grid container spacing={3} data-testid="single-project-view">
+          <Grid md={6} xs={12} data-testid="project-card">
+            <JiraProjectCard project={projects[0]} />
+          </Grid>
+          {jiraResponse.data.map((value: JiraDataResponse) => (
+            <Grid data-testid="issue-table" key={value.name} md={6} xs={12}>
+              <JiraTable
+                tableContent={value}
+                showFilters={props?.showFilters}
+                project={projects[0]}
+                tableOptions={props?.tableOptions}
+                tableStyle={{
+                  height: 'max-content',
+                  maxHeight: '500px',
+                  padding: '20px',
+                  overflowY: 'auto',
+                  width: '100%',
+                }}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Content>
   );
 };

--- a/plugins/jira-dashboard/src/hooks/useJira.ts
+++ b/plugins/jira-dashboard/src/hooks/useJira.ts
@@ -22,10 +22,13 @@ export function useJira(
     error,
   } = useAsync(async (): Promise<any> => {
     const response = await jiraDashboardApi.getJiraResponseByEntity(entityRef);
-    response.project.avatarUrls = await jiraDashboardApi.getProjectAvatar(
-      entityRef,
-    );
-    return response;
+    const project = Array.isArray(response.project)
+      ? response.project
+      : [response.project];
+    return {
+      project,
+      data: response.data || [],
+    };
   });
   return { data, loading, error };
 }


### PR DESCRIPTION
Signed-off-by: enaysaa saachi.nayyer@ericsson.com

## Hey, I just made a Pull Request!

for components with multiple project keys in annotation, project card will be displayed in tabbed view for all keys
![image](https://github.com/user-attachments/assets/fcc7c14f-6395-47cf-9432-b1f662475ec8)
 

### Context

Currently project card is displayed for 1st project key, only this change shows project card in tabbed view for multiple keys

### Issue ticket number and link

- Fixes # (issue)
https://github.com/AxisCommunications/backstage-plugins/issues/279

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
