### PR TITLE
feat(readme-backend): added config to set the cache ttl

### DIFF
--- a/.changeset/many-baboons-lick.md
+++ b/.changeset/many-baboons-lick.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Added config to set the cache ttl.

--- a/plugins/readme-backend/README.md
+++ b/plugins/readme-backend/README.md
@@ -46,6 +46,20 @@ readme:
     - README.markdown
 ```
 
+To override the default TTL of the internal cache a duration can be set using the `cacheTtl` key. This can be either a string
+or an object. The following examples should be equal.
+
+```yaml
+readme:
+  cacheTtl:
+    hours: 2
+```
+
+```yaml
+readme:
+  cacheTtl: '2h'
+```
+
 ### Troubleshooting
 
 If the backend fails to provide README content for an entity, it could be due to several reasons.

--- a/plugins/readme-backend/config.d.ts
+++ b/plugins/readme-backend/config.d.ts
@@ -1,3 +1,5 @@
+import { HumanDuration } from '@backstage/types';
+
 export interface Config {
   /**
    * Configuration options for the Readme backend plugin
@@ -8,5 +10,9 @@ export interface Config {
      * when looking for a README file and which order to use.
      */
     fileNames?: string[];
+    /**
+     * Optional cache TTL, defaults to 1 hour.
+     */
+    cacheTtl?: HumanDuration | string;
   };
 }

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -32,8 +32,10 @@
     "@backstage/backend-plugin-api": "^1.2.0",
     "@backstage/catalog-client": "^1.9.1",
     "@backstage/catalog-model": "^1.7.3",
+    "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.16.1",
+    "@backstage/types": "^1.2.1",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0"
@@ -41,7 +43,6 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.3.0",
     "@backstage/cli": "^0.30.0",
-    "@backstage/config": "^1.3.2",
     "@types/supertest": "^2.0.12",
     "msw": "^2.7.3",
     "supertest": "^6.2.4"

--- a/plugins/readme-backend/src/service/config.test.ts
+++ b/plugins/readme-backend/src/service/config.test.ts
@@ -1,0 +1,101 @@
+import { mockServices } from '@backstage/backend-test-utils';
+
+import { getCacheTtl } from './config';
+
+describe('getCacheTtl', () => {
+  it('should return default TTL when cache.ttl is not configured', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {},
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(3_600_000); // 1 hour in milliseconds
+  });
+
+  it('should return default TTL when readme config section exists but no ttl key', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {},
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(3_600_000); // 1 hour in milliseconds
+  });
+
+  it('should return configured TTL in seconds', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {
+          cacheTtl: { seconds: 1800 }, // 30 minutes
+        },
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(1_800_000); // 30 minutes in milliseconds
+  });
+
+  it('should return configured TTL in minutes', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {
+          cacheTtl: { minutes: 10 },
+        },
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(600_000); // 10 minutes in milliseconds
+  });
+
+  it('should return configured TTL in hours', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {
+          cacheTtl: { hours: 2 },
+        },
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(7_200_000); // 2 hours in milliseconds
+  });
+
+  it('should return configured TTL as a string value (interpreted as milliseconds)', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {
+          cacheTtl: '4w',
+        },
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(2419200000); // 4 weeks in milliseconds
+  });
+
+  it('should handle complex duration configuration', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        readme: {
+          cacheTtl: {
+            hours: 1,
+            minutes: 30,
+            seconds: 45,
+          },
+        },
+      },
+    });
+
+    const result = getCacheTtl(mockConfig);
+
+    expect(result).toBe(5_445_000); // 1h 30m 45s in milliseconds
+  });
+});

--- a/plugins/readme-backend/src/service/config.ts
+++ b/plugins/readme-backend/src/service/config.ts
@@ -1,0 +1,11 @@
+import { Config, readDurationFromConfig } from '@backstage/config';
+import { durationToMilliseconds } from '@backstage/types';
+
+const CACHE_CONFIG_KEY = 'readme.cacheTtl';
+
+export const getCacheTtl = (config: Config): number =>
+  config.has(CACHE_CONFIG_KEY)
+    ? durationToMilliseconds(
+        readDurationFromConfig(config, { key: CACHE_CONFIG_KEY }),
+      )
+    : 3_600_000;

--- a/plugins/readme-backend/src/service/constants.test.ts
+++ b/plugins/readme-backend/src/service/constants.test.ts
@@ -1,4 +1,4 @@
-import { ConfigReader } from '@backstage/config';
+import { mockServices } from '@backstage/backend-test-utils';
 import { NOT_FOUND_PLACEHOLDER, getReadmeTypes } from './constants';
 
 describe('constants', () => {
@@ -11,7 +11,9 @@ describe('constants', () => {
 
   describe('getReadmeTypes', () => {
     it('should return default readme types when config is empty', () => {
-      const config = new ConfigReader({});
+      const config = mockServices.rootConfig({
+        data: {},
+      });
       const readmeTypes = getReadmeTypes(config);
       expect(readmeTypes).toEqual([
         { name: 'README.md', type: 'text/markdown' },
@@ -23,9 +25,11 @@ describe('constants', () => {
     });
 
     it('should return custom readme types from config', () => {
-      const config = new ConfigReader({
-        readme: {
-          fileNames: ['CUSTOM.md', 'CUSTOM.txt'],
+      const config = mockServices.rootConfig({
+        data: {
+          readme: {
+            fileNames: ['CUSTOM.md', 'CUSTOM.txt'],
+          },
         },
       });
       const readmeTypes = getReadmeTypes(config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,7 @@ __metadata:
     "@backstage/config": "npm:^1.3.2"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/integration": "npm:^1.16.1"
+    "@backstage/types": "npm:^1.2.1"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^2.0.12"
     express: "npm:^4.17.1"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the "readme-backend" plugin no ttl where configured, this PR sets a default 1 hour ttl and makes it possible to override this using the config.

### Issue ticket number and link

- Fixes #287 287

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
