### PR TITLE
feat: Add jql annotation to Jira Dashboard plugin

### DIFF
--- a/.changeset/quiet-coats-glow.md
+++ b/.changeset/quiet-coats-glow.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': minor
+'@axis-backstage/plugin-jira-dashboard-common': minor
+'@axis-backstage/plugin-jira-dashboard': minor
+---
+
+Add jql annotation to the Jira plugins to allow fully customization of the issues displayed in the Jira Dashboard

--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -14,8 +14,6 @@ metadata:
   name: example-website
   annotations:
     jira.com/project-key: BS
-    # jira/project-key: BS
-
 spec:
   type: website
   lifecycle: experimental

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -143,6 +143,7 @@ export const searchJira = async (
 export const getIssuesByComponent = async (
   projects: JiraProject[],
   componentKeys: string,
+  query?: string,
 ): Promise<Issue[]> => {
   // Return an empty array if no projects are provided
   if (projects.length === 0) {
@@ -157,6 +158,7 @@ export const getIssuesByComponent = async (
   const jql = jqlQueryBuilder({
     project: projectKeys,
     components,
+    query,
   });
 
   const { instance } = projects[0];

--- a/plugins/jira-dashboard-backend/src/lib.ts
+++ b/plugins/jira-dashboard-backend/src/lib.ts
@@ -5,6 +5,7 @@ import {
   INCOMING_ISSUES_STATUS,
   Project,
   Issue,
+  JQL,
 } from '@axis-backstage/plugin-jira-dashboard-common';
 
 import type { ConfigInstance, JiraConfig } from './config';
@@ -13,6 +14,7 @@ export const getAnnotations = (config: JiraConfig) => {
   const prefix = config.annotationPrefix;
 
   const projectKeyAnnotation = `${prefix}/${PROJECT_KEY_NAME}`;
+  const jqlAnnotation = `${prefix}/${JQL}`;
   const componentsAnnotation = `${prefix}/${COMPONENTS_NAME}`;
   const filtersAnnotation = `${prefix}/${FILTERS_NAME}`;
   const incomingIssuesAnnotation = `${prefix}/${INCOMING_ISSUES_STATUS}`;
@@ -22,6 +24,7 @@ export const getAnnotations = (config: JiraConfig) => {
 
   return {
     projectKeyAnnotation,
+    jqlAnnotation,
     componentsAnnotation,
     filtersAnnotation,
     incomingIssuesAnnotation,

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -106,6 +106,7 @@ export async function createRouter(
       const entity = await catalogClient.getEntityByRef(entityRef, { token });
       const {
         projectKeyAnnotation,
+        jqlAnnotation,
         componentsAnnotation,
         filtersAnnotation,
         incomingIssuesAnnotation,
@@ -191,6 +192,9 @@ export async function createRouter(
 
       let components =
         entity.metadata.annotations?.[componentsAnnotation]?.split(',') ?? [];
+
+      const jqlValue = entity.metadata.annotations?.[jqlAnnotation] ?? '';
+
       const projectKeys = projects.map(project => project.projectKey);
       let issues = await getIssuesFromFilters(
         projectKeys,
@@ -198,6 +202,7 @@ export async function createRouter(
         filters,
         instance,
         cache,
+        jqlValue,
       );
 
       /* Adding support for Roadie's component annotation */
@@ -212,6 +217,7 @@ export async function createRouter(
           components,
           instance,
           cache,
+          jqlValue,
         );
         issues = issues.concat(componentIssues);
       }

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -154,6 +154,7 @@ export const getIssuesFromFilters = async (
   filters: Filter[],
   instance: ConfigInstance,
   cache: CacheService,
+  jqlAnnotation?: string,
 ): Promise<JiraDataResponse[]> => {
   const projects = await getJiraProjectsFromKeys(projectKeys, instance, cache);
   return await Promise.all(
@@ -162,7 +163,9 @@ export const getIssuesFromFilters = async (
       query: jqlQueryBuilder({
         project: projectKeys,
         components,
-        query: filter.query,
+        query: `${jqlAnnotation ? `(${jqlAnnotation}) AND ` : ''}${
+          filter.query
+        }`,
       }),
       type: 'filter',
       issues: await getIssuesByFilter(projects, components, filter.query),
@@ -175,6 +178,7 @@ export const getIssuesFromComponents = async (
   componentAnnotations: string[],
   instance: ConfigInstance,
   cache: CacheService,
+  jqlAnnotation?: string,
 ): Promise<JiraDataResponse[]> => {
   const projects = await getJiraProjectsFromKeys(projectKeys, instance, cache);
   return await Promise.all(
@@ -183,9 +187,14 @@ export const getIssuesFromComponents = async (
       query: jqlQueryBuilder({
         project: projectKeys,
         components: [componentKey],
+        query: jqlQueryBuilder({
+          project: projectKeys,
+          components: componentAnnotations,
+          query: jqlAnnotation,
+        }),
       }),
       type: 'component',
-      issues: await getIssuesByComponent(projects, componentKey),
+      issues: await getIssuesByComponent(projects, componentKey, jqlAnnotation),
     })),
   );
 };

--- a/plugins/jira-dashboard-common/report.api.md
+++ b/plugins/jira-dashboard-common/report.api.md
@@ -77,6 +77,9 @@ export type JiraResponse = {
 };
 
 // @public
+export const JQL = 'jql';
+
+// @public
 export type Project = {
   name: string;
   key: string;

--- a/plugins/jira-dashboard-common/src/annotations.ts
+++ b/plugins/jira-dashboard-common/src/annotations.ts
@@ -9,6 +9,12 @@
 export const PROJECT_KEY_NAME = 'project-key';
 
 /**
+ * The annotation name used to provide a JQL query to filter issues for this entity
+ *  @public
+ */
+export const JQL = 'jql';
+
+/**
  * The annotation name used to provide the Jira components to track for this entity
  *  @public
  */

--- a/plugins/jira-dashboard/README.md
+++ b/plugins/jira-dashboard/README.md
@@ -164,9 +164,24 @@ metadata:
     jira.com/project-key: abc,bcd,def # Comma-separated list of Jira project keys
 ```
 
+### Custom JQL Annotation
+
+To fully customize which issues are displayed in the Jira Dashboard for your entity, you can use the `jira.com/jql` annotation.  
+This annotation lets you specify any [Jira Query Language (JQL)](https://support.atlassian.com/jira-service-management-cloud/docs/use-advanced-search-with-jira-query-language-jql) query, giving you complete control over the issue filtering. Only issues matching your custom JQL will be shown.
+
+**Example:**
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    jira.com/jql: component = OurProject AND Affected = 1.1
+```
+
 ### Optional annotations
 
-If you want to track specific components or filters for your entity, you can add the optional annotations `components` and `filters-ids`. You can specify an endless number of Jira components or filters.
+If you want to track specific components or filters for your entity, you can add the optional annotations `components` and `filters-ids`. You can specify an endless number of Jira components or filters. A separate Jira issues table will be displayed for each component or filter you specify.
 
 If your Jira project does not use "New" as status for incoming issues, you can specify which status to use through the `incoming-issues-status` annotation.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for the new `jira.com/jql annotation as a prefilter for all Jira queries in the backend. The annotation is combined with filter and component queries. 

### Context

Some entities need to display only specific Jira issues, for example from a particular instance or based on custom criterias.

This change allows the use of the jira.com/jql annotation to filter issues more precisely, making it possible to customize which issues are shown for each entity.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
