### PR TITLE
feat(api-v3): added flag to use api v3

### DIFF
--- a/.changeset/clean-plants-love.md
+++ b/.changeset/clean-plants-love.md
@@ -1,0 +1,23 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': major
+---
+
+Added support for Jira Cloud API V3
+
+Added useApiV3 configuration option to enable Jira REST API v3 support. The "/api/2/search"
+API used by the Jira Data Center is deprecated and may not be available in Jira Cloud.
+
+Configuration Changes:
+
+Added optional useApiV3 boolean field to the Jira dashboard configuration
+When useApiV3: true, API calls use the /search/jql endpoint instead of /search
+When useApiV3: false or not specified, continues to use the existing v2 /search endpoint
+
+Example configuration for Jira Cloud to use the v3 Api.
+
+```
+jiraDashboard:
+baseUrl: 'https://your-jira.atlassian.net/rest/api/3/'
+token: 'your-token'
+useApiV3: true
+```

--- a/plugins/jira-dashboard-backend/README.md
+++ b/plugins/jira-dashboard-backend/README.md
@@ -47,6 +47,36 @@ jiraDashboard:
   annotationPrefix: jira
 ```
 
+### Jira API Version Configuration
+
+The plugin supports both Jira REST API v2 (default) and v3. You can enable API v3 by setting the `useApiV3` configuration option:
+
+```yaml
+jiraDashboard:
+  token: ${JIRA_TOKEN}
+  baseUrl: ${JIRA_BASE_URL}
+  useApiV3: true # Enable Jira API v3 (defaults to false)
+```
+
+#### API Version Differences:
+
+- **API v2 (default)**: Uses the `/search` endpoint for JQL queries
+- **API v3**: Uses the `/search/jql` endpoint for JQL queries
+
+When `useApiV3` is set to `true`, the plugin will use the v3 API endpoints. When `useApiV3` is `false` or not specified, the plugin will continue to use the v2 API endpoints for backward compatibility.
+
+#### Example with API v3:
+
+```yaml
+jiraDashboard:
+  token: Bearer <your-token>
+  baseUrl: https://your-domain.atlassian.net/rest/api/3/
+  useApiV3: true
+  userEmailSuffix: @your-company.com
+```
+
+**Note**: When using API v3, make sure your `baseUrl` also points to the v3 endpoint (e.g., `/rest/api/3/` instead of `/rest/api/2/`).
+
 ### Multiple Jira instances
 
 In case multiple Jira instances are being used, the configuration can be written on the form:
@@ -61,13 +91,17 @@ jiraDashboard:
       apiUrl: ${JIRA_API_URL} # Optional
       headers: {} # Optional
       userEmailSuffix: ${JIRA_EMAIL_SUFFIX} # Optional
+      useApiV3: false # Optional - defaults to false
     - name: separate-jira-instance
       token: ${JIRA_TOKEN_SEPARATE}
       baseUrl: ${JIRA_BASE_URL_SEPARATE}
       apiUrl: ${JIRA_API_URL_SEPARATE} # Optional
       headers: {} # Optional
       userEmailSuffix: ${JIRA_EMAIL_SUFFIX_SEPARATE} # Optional
+      useApiV3: true # Optional - enable API v3 for this instance
 ```
+
+Each instance can have its own `useApiV3` setting, allowing you to mix v2 and v3 API usage across different Jira instances.
 
 In entity yamls that don't specify an instance, the one called `"default"` will be used. To specify another instace, prefix the project key with `instance-name/` such as:
 

--- a/plugins/jira-dashboard-backend/config.d.ts
+++ b/plugins/jira-dashboard-backend/config.d.ts
@@ -34,7 +34,7 @@ export interface Config {
         userEmailSuffix?: string;
 
         /**
-         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * Optional annotation prefix for retrieving a custom annotation. Default value is jira.com
          * @visibility frontend
          */
         annotationPrefix?: string;
@@ -48,12 +48,17 @@ export interface Config {
           shortName: string;
         }[];
 
+        /**
+         * Whether to use Jira API v3. Defaults to false for backward compatibility.
+         */
+        useApiV3?: boolean;
+
         // Type helper
         instances?: never;
       }
     | {
         /**
-         * Optional annotation prefix for retrieving a custom annotation. Defaut value is jira.com
+         * Optional annotation prefix for retrieving a custom annotation. Default value is jira.com
          * @visibility frontend
          */
         annotationPrefix?: string;
@@ -101,6 +106,11 @@ export interface Config {
             query: string;
             shortName: string;
           }[];
+
+          /**
+           * Whether to use Jira API v3. Defaults to false for backward compatibility.
+           */
+          useApiV3?: boolean;
         }[];
       };
 }

--- a/plugins/jira-dashboard-backend/report.api.md
+++ b/plugins/jira-dashboard-backend/report.api.md
@@ -25,6 +25,7 @@ export type ConfigInstance = {
   apiUrl?: string;
   userEmailSuffix?: string;
   defaultFilters?: Filter[];
+  useApiV3?: boolean;
 };
 
 // @public

--- a/plugins/jira-dashboard-backend/src/config.ts
+++ b/plugins/jira-dashboard-backend/src/config.ts
@@ -28,6 +28,7 @@ export type ConfigInstance = {
   apiUrl?: string;
   userEmailSuffix?: string;
   defaultFilters?: Filter[];
+  useApiV3?: boolean;
 };
 
 const JIRA_CONFIG_BASE_URL = 'baseUrl';
@@ -37,6 +38,7 @@ const JIRA_CONFIG_HEADERS = 'headers';
 const JIRA_CONFIG_USER_EMAIL_SUFFIX = 'userEmailSuffix';
 const JIRA_CONFIG_ANNOTATION = 'annotationPrefix';
 const JIRA_FILTERS = 'defaultFilters';
+const JIRA_CONFIG_USE_API_V3 = 'useApiV3';
 
 /**
  * Class for reading Jira configuration from the root config
@@ -82,6 +84,7 @@ export class JiraConfig {
               shortName: filterConfig.getString('shortName'),
               query: filterConfig.getString('query'),
             })),
+          useApiV3: inst.getOptionalBoolean(JIRA_CONFIG_USE_API_V3) ?? false,
         };
       });
     } else {
@@ -99,6 +102,7 @@ export class JiraConfig {
             shortName: filterConfig.getString('shortName'),
             query: filterConfig.getString('query'),
           })),
+        useApiV3: jira.getOptionalBoolean(JIRA_CONFIG_USE_API_V3) ?? false,
       };
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for Jira Cloud API V3

Added useApiV3 configuration option to enable Jira REST API v3 support. The "/api/2/search"
API used by the Jira Data Center is deprecated and may not be available in Jira Cloud.

Configuration Changes:

Added optional useApiV3 boolean field to the Jira dashboard configuration
When useApiV3: true, API calls use the /search/jql endpoint instead of /search
When useApiV3: false or not specified, continues to use the existing v2 /search endpoint

Example configuration for Jira Cloud to use the v3 Api.

```
jiraDashboard:
baseUrl: 'https://your-jira.atlassian.net/rest/api/3/'
token: 'your-token'
useApiV3: true
```
Fixes #321 
