### PR TITLE
feat(jira-dashboard): remove ContentHeader and Content wrapper

### DIFF
--- a/.changeset/floppy-jokes-juggle.md
+++ b/.changeset/floppy-jokes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Removed the `ContentHeader` (with `SupportButton`) and the wrapping `Content` component from `JiraDashboardContent` to align the layout with other plugins in this repo.

--- a/.changeset/loud-actors-return.md
+++ b/.changeset/loud-actors-return.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Fixes missing spacing between the project card and issue table cards in the Jira Dashboard.

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.test.tsx
@@ -52,17 +52,6 @@ describe('JiraDashboardContent', () => {
 
   afterAll(() => server.close());
 
-  it('renders component', async () => {
-    const rendered = await renderInTestApp(
-      <EntityProvider entity={mockedEntity}>
-        <ApiProvider apis={apis}>
-          <JiraDashboardContent />
-        </ApiProvider>
-      </EntityProvider>,
-    );
-    expect(rendered.getByText(/Jira Dashboard/)).toBeInTheDocument();
-  });
-
   it('renders project card', async () => {
     const { getByTestId } = await renderInTestApp(
       <EntityProvider entity={mockedEntity}>
@@ -164,11 +153,6 @@ describe('JiraDashboardContent - Multi-project response', () => {
     );
     jiraClient = new JiraDashboardClient({ discoveryApi, fetchApi });
     apis = TestApiRegistry.from([jiraDashboardApiRef, jiraClient]);
-  });
-
-  it('renders the dashboard title', async () => {
-    const { getByText } = await renderComponent();
-    expect(getByText(/Jira Dashboard/i)).toBeInTheDocument();
   });
 
   it('renders 1 project card and 2 tables per tab', async () => {

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -1,16 +1,11 @@
 import {
-  Content,
-  ContentHeader,
   Progress,
   ResponseErrorPanel,
-  SupportButton,
   TableFilter,
   TableOptions,
   TabbedCard,
   CardTab,
 } from '@backstage/core-components';
-import Typography from '@mui/material/Typography';
-import Link from '@mui/material/Link';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { stringifyEntityRef } from '@backstage/catalog-model';
@@ -49,22 +44,7 @@ export const JiraDashboardContent = (props?: {
     : [];
 
   return (
-    <Content>
-      <ContentHeader title="Jira Dashboard">
-        <SupportButton>
-          <Typography variant="h6">How it works</Typography>
-          The Jira Dashboard plugin provides quick access to Jira issue
-          summaries. Add Jira components and filters via annotations in your
-          entity's `catalog-info.yaml`.
-          <Typography mt={1} variant="h6">
-            Documentation
-          </Typography>
-          <Link href="https://github.com/AxisCommunications/backstage-plugins/tree/main/plugins/jira-dashboard">
-            here.
-          </Link>
-        </SupportButton>
-      </ContentHeader>
-
+    <>
       {projects.length > 1 ? (
         <TabbedCard title="Jira Projects" data-testid="tabbed-card">
           {projects.map(project => (
@@ -86,6 +66,6 @@ export const JiraDashboardContent = (props?: {
           tableOptions={props?.tableOptions}
         />
       )}
-    </Content>
+    </>
   );
 };

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraDashboardContent.tsx
@@ -43,29 +43,25 @@ export const JiraDashboardContent = (props?: {
     ? jiraResponse.project
     : [];
 
-  return (
-    <>
-      {projects.length > 1 ? (
-        <TabbedCard title="Jira Projects" data-testid="tabbed-card">
-          {projects.map(project => (
-            <CardTab key={project.key} label={project.name}>
-              <JiraGrid
-                project={project}
-                tableData={jiraResponse.data}
-                showFilters={props?.showFilters}
-                tableOptions={props?.tableOptions}
-              />
-            </CardTab>
-          ))}
-        </TabbedCard>
-      ) : (
-        <JiraGrid
-          project={projects[0]}
-          tableData={jiraResponse.data}
-          showFilters={props?.showFilters}
-          tableOptions={props?.tableOptions}
-        />
-      )}
-    </>
+  return projects.length > 1 ? (
+    <TabbedCard title="Jira Projects" data-testid="tabbed-card">
+      {projects.map(project => (
+        <CardTab key={project.key} label={project.name}>
+          <JiraGrid
+            project={project}
+            tableData={jiraResponse.data}
+            showFilters={props?.showFilters}
+            tableOptions={props?.tableOptions}
+          />
+        </CardTab>
+      ))}
+    </TabbedCard>
+  ) : (
+    <JiraGrid
+      project={projects[0]}
+      tableData={jiraResponse.data}
+      showFilters={props?.showFilters}
+      tableOptions={props?.tableOptions}
+    />
   );
 };

--- a/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraGrid.tsx
+++ b/plugins/jira-dashboard/src/components/JiraDashboardContent/JiraGrid.tsx
@@ -22,12 +22,25 @@ export const JiraGrid = ({
   tableOptions,
 }: JiraGridProps) => {
   return (
-    <Grid container spacing={3}>
-      <Grid item xs={12} xl={6} data-testid="project-card">
+    <Grid container spacing={3} style={{ width: '100%' }}>
+      <Grid
+        item
+        xs={12}
+        xl={6}
+        data-testid="project-card"
+        style={{ paddingTop: '24px', paddingLeft: '24px' }}
+      >
         <JiraProjectCard project={project} />
       </Grid>
       {tableData.map((value: JiraDataResponse) => (
-        <Grid item xs={12} xl={6} key={value.name} data-testid="issue-table">
+        <Grid
+          item
+          xs={12}
+          xl={6}
+          key={value.name}
+          data-testid="issue-table"
+          style={{ paddingTop: '24px', paddingLeft: '24px' }}
+        >
           <JiraTable
             tableContent={value}
             showFilters={showFilters}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the `ContentHeader` (with `SupportButton`) and the wrapping `Content` component from `JiraDashboardContent` to align the layout with other plugins in this repo.

This change removes the Support button, but I think it makes more sense to add it to the first info card as it's done in other plugins.

### Context

Other plugins in this monorepo (e.g. `StatuspageComponent`) render content directly inside the entity tab without a `Content` wrapper or a page-level `ContentHeader`. This change brings the Jira Dashboard plugin in line with that pattern, reducing visual inconsistency across the portal.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)