### PR TITLE
refactor(jira-dashboard-backend): parallelize async operations with P…

### DIFF
--- a/.changeset/quick-candles-unite.md
+++ b/.changeset/quick-candles-unite.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Refactored the Jira Dashboard backend to batch project keys into a single JQL query (getIssuesByFilter) and to run independent async operations concurrently with Promise.all / Promise.allSettled, reducing latency when multiple projects or filters are fetched.

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -81,31 +81,38 @@ export const getIssuesByFilter = async (
   components: string[],
   query: string,
 ): Promise<Issue[]> => {
-  const issues: Issue[] = [];
-  for (const project of projects) {
-    const { projectKey, instance } = project;
-    const jql = jqlQueryBuilder({ project: [projectKey], components, query });
-    const queryUrl = getQueryUrl(instance, jql);
-    const response = await callApi(instance, queryUrl, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-      },
-    })
-      .then(resp => resp.json())
-      .catch(() => null);
-    if (response?.errorMessages) {
-      throw Error(
-        `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages?.[0]}`,
-      );
-    }
-    if (response?.issues) {
-      replaceIssuesApiUrl(project.instance, response.issues);
-      issues.push(...response.issues);
-    }
+  if (projects.length === 0) {
+    return [];
   }
 
-  return issues;
+  // All projects are expected to share the same instance — callers (getJiraProjectsFromKeys)
+  // stamp every project with the same ConfigInstance, so a single batched JQL query suffices.
+  const { instance } = projects[0];
+  const projectKeys = projects.map(p => p.projectKey);
+  const jql = jqlQueryBuilder({ project: projectKeys, components, query });
+  const queryUrl = getQueryUrl(instance, jql);
+
+  const response = await callApi(instance, queryUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+    .then(resp => resp.json())
+    .catch(() => null);
+
+  if (response?.errorMessages) {
+    throw Error(
+      `JQL returned Error: JQL -  ${jql} with error: ${response?.errorMessages?.[0]}`,
+    );
+  }
+
+  if (response?.issues) {
+    replaceIssuesApiUrl(instance, response.issues);
+    return response.issues;
+  }
+
+  return [];
 };
 
 /**

--- a/plugins/jira-dashboard-backend/src/service/router.ts
+++ b/plugins/jira-dashboard-backend/src/service/router.ts
@@ -120,21 +120,24 @@ export async function createRouter(
       const projects = fullProjectKeys.map(fullProjectKey =>
         splitProjectKey(config, fullProjectKey),
       );
-      const projectResponses: Project[] = [];
+      const projectResults = await Promise.allSettled(
+        projects.map(project => getProjectResponse(project, cache)),
+      );
 
-      for (const project of projects) {
-        try {
-          const projectData = await getProjectResponse(project, cache);
-          projectResponses.push(projectData);
-        } catch (err: any) {
+      const projectResponses: Project[] = [];
+      for (const [i, result] of projectResults.entries()) {
+        if (result.status === 'rejected') {
           logger.error(
-            `Could not find Jira project ${project.fullProjectKey}: ${err.message}`,
+            `Could not find Jira project ${projects[i].fullProjectKey}: ${
+              result.reason?.message ?? result.reason
+            }`,
           );
           response.status(404).json({
-            error: `Jira project not found with key ${project.fullProjectKey}`,
+            error: `Jira project not found with key ${projects[i].fullProjectKey}`,
           });
           return;
         }
+        projectResponses.push(result.value);
       }
 
       let userEntity: UserEntity | undefined;

--- a/plugins/jira-dashboard-backend/src/service/service.ts
+++ b/plugins/jira-dashboard-backend/src/service/service.ts
@@ -107,48 +107,49 @@ export const getFiltersFromAnnotations = async (
   annotations: string[],
   config: ConfigInstance,
 ): Promise<Filter[]> => {
-  const filters: Filter[] = [];
+  const results = await Promise.allSettled(
+    annotations.map(filter => getFilterById(filter, config)),
+  );
 
-  for (const filter of annotations) {
-    try {
-      const response = await getFilterById(filter, config);
-      filters.push(response);
-    } catch (err: any) {
-      console.warn(
-        `${err.message} : Could not find filter with filter id ${filter}`,
-      );
-    }
-  }
-  return filters;
+  return results
+    .map((result, i) => {
+      if (result.status === 'rejected') {
+        console.warn(
+          `${result.reason.message} : Could not find filter with filter id ${annotations[i]}`,
+        );
+        return null;
+      }
+      return result.value;
+    })
+    .filter((filter): filter is Filter => filter !== null);
 };
 async function getJiraProjectsFromKeys(
   projectKeys: string[],
   instance: ConfigInstance,
   cache: CacheService,
 ): Promise<JiraProject[]> {
-  const jiraProjects: JiraProject[] = [];
-  for (const key of projectKeys) {
-    const cachedProject = (await cache.get(key)) as Project;
-    let projectInfo: Project;
+  return Promise.all(
+    projectKeys.map(async key => {
+      const cachedProject = (await cache.get(key)) as Project;
+      const projectInfo =
+        cachedProject ??
+        (await getProjectInfo({
+          projectKey: key,
+          instance,
+          fullProjectKey: '',
+        }));
 
-    if (cachedProject) {
-      projectInfo = cachedProject;
-    } else {
-      projectInfo = await getProjectInfo({
-        projectKey: key,
+      if (!cachedProject) {
+        cache.set(key, projectInfo, { ttl: instance.cacheTtl });
+      }
+
+      return {
         instance,
-        fullProjectKey: '',
-      });
-      cache.set(key, projectInfo, { ttl: instance.cacheTtl });
-    }
-
-    jiraProjects.push({
-      instance,
-      fullProjectKey: projectInfo.key,
-      projectKey: projectInfo.key,
-    });
-  }
-  return jiraProjects;
+        fullProjectKey: projectInfo.key,
+        projectKey: projectInfo.key,
+      };
+    }),
+  );
 }
 export const getIssuesFromFilters = async (
   projectKeys: string[],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refactored sequential `for` loops in the Jira Dashboard backend to use `Promise.all` / `Promise.allSettled`, reducing latency when multiple projects or filters are fetched.

### Context

The backend was fetching Jira projects, filters, and issues sequentially in `for` loops. For entities with multiple projects or many filter annotations, each request waited for the previous to complete. This change parallelizes those fetch calls, reducing total response time proportionally to the number of items.

Additionally, `getIssuesByFilter` was making one API call per project. Since Jira's JQL supports multi-project queries (`project IN (A, B, C)`), all projects are now batched into a single request.

### Issue ticket number and link

- Fixes # (issue)

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)