### PR TITLE
Refactor/readme backend catalog service

### DIFF
--- a/.changeset/readme-backend-catalog-service.md
+++ b/.changeset/readme-backend-catalog-service.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Replaced internally constructed `CatalogClient` with the injected `CatalogService` from `@backstage/plugin-catalog-node`. This removes the dependency on `@backstage/catalog-client` and `@backstage/backend-defaults`, improves testability, and fixes unawaited cache writes.

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -29,18 +29,17 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.6.2",
-    "@backstage/catalog-client": "^1.12.1",
     "@backstage/catalog-model": "^1.7.6",
     "@backstage/config": "^1.3.6",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.19.1",
+    "@backstage/plugin-catalog-node": "^1.20.0",
     "@backstage/types": "^1.2.2",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0"
   },
   "devDependencies": {
-    "@backstage/backend-defaults": "^0.15.1",
     "@backstage/backend-test-utils": "^1.10.4",
     "@backstage/cli": "^0.35.1",
     "@types/supertest": "^2.0.12",

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -40,6 +40,7 @@
     "express-promise-router": "^4.1.0"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "^0.15.1",
     "@backstage/backend-test-utils": "^1.10.4",
     "@backstage/cli": "^0.35.1",
     "@types/supertest": "^2.0.12",

--- a/plugins/readme-backend/src/plugin.ts
+++ b/plugins/readme-backend/src/plugin.ts
@@ -2,6 +2,7 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { createRouter } from './service/router';
 
 /**
@@ -16,7 +17,7 @@ export const readmePlugin = createBackendPlugin({
       deps: {
         auth: coreServices.auth,
         config: coreServices.rootConfig,
-        discovery: coreServices.discovery,
+        catalogApi: catalogServiceRef,
         httpRouter: coreServices.httpRouter,
         logger: coreServices.logger,
         reader: coreServices.urlReader,
@@ -25,9 +26,9 @@ export const readmePlugin = createBackendPlugin({
       async init({
         auth,
         logger,
+        catalogApi,
         config,
         reader,
-        discovery,
         httpRouter,
         cache,
       }) {
@@ -35,9 +36,9 @@ export const readmePlugin = createBackendPlugin({
           await createRouter({
             auth,
             logger,
+            catalogApi,
             config,
             reader,
-            discovery,
             cache,
           }),
         );

--- a/plugins/readme-backend/src/service/router.test.ts
+++ b/plugins/readme-backend/src/service/router.test.ts
@@ -1,5 +1,6 @@
 import { mockServices } from '@backstage/backend-test-utils';
-import { UrlReaders } from '@backstage/backend-defaults/urlReader';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+
 import express from 'express';
 import request from 'supertest';
 
@@ -7,19 +8,20 @@ import { createRouter } from './router';
 
 describe('createRouter', () => {
   let app: express.Express;
+  const catalogApi = catalogServiceMock.mock();
 
   beforeAll(async () => {
+    const auth = mockServices.auth.mock();
     const config = mockServices.rootConfig();
     const logger = mockServices.rootLogger.mock();
-    const discovery = mockServices.discovery.mock();
     const cache = mockServices.cache.mock();
-    const reader = UrlReaders.default({ logger, config });
+    const reader = mockServices.urlReader.mock();
 
     const router = await createRouter({
-      auth: mockServices.auth.mock(),
+      auth,
+      catalogApi,
       logger,
       config,
-      discovery,
       reader,
       cache,
     });

--- a/plugins/readme-backend/src/service/router.ts
+++ b/plugins/readme-backend/src/service/router.ts
@@ -1,17 +1,16 @@
 import {
   AuthService,
   CacheService,
-  DiscoveryService,
   LoggerService,
   RootConfigService,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import { ScmIntegrations } from '@backstage/integration';
 import {
   getEntitySourceLocation,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { CatalogClient } from '@backstage/catalog-client';
 import { isError, NotFoundError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
@@ -26,8 +25,8 @@ import { ReadmeFile } from './types';
  */
 interface RouterOptions {
   auth: AuthService;
+  catalogApi: CatalogService;
   config: RootConfigService;
-  discovery: DiscoveryService;
   logger: LoggerService;
   reader: UrlReaderService;
   cache: CacheService;
@@ -40,9 +39,9 @@ interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { auth, logger, config, reader, discovery, cache } = options;
-  const catalogClient = new CatalogClient({ discoveryApi: discovery });
+  const { auth, logger, config, reader, catalogApi, cache } = options;
   const cacheTtl = getCacheTtl(config);
+  const readmeTypes = getReadmeTypes(config);
 
   logger.info(`Initializing readme backend. Cache TTL: ${cacheTtl}ms`);
   const integrations = ScmIntegrations.fromConfig(config);
@@ -67,11 +66,9 @@ export async function createRouter(
       response.send(cacheDoc.content);
       return;
     }
-    const { token } = await auth.getPluginRequestToken({
-      onBehalfOf: await auth.getOwnServiceCredentials(),
-      targetPluginId: 'catalog',
+    const entity = await catalogApi.getEntityByRef(entityRef, {
+      credentials: await auth.getOwnServiceCredentials(),
     });
-    const entity = await catalogClient.getEntityByRef(entityRef, { token });
     if (!entity) {
       logger.info(`No integration found for ${entityRef}`);
       response
@@ -95,8 +92,6 @@ export async function createRouter(
         .json({ error: `No integration found for ${source.target}` });
       return;
     }
-
-    const readmeTypes = getReadmeTypes(config);
 
     for (const fileType of readmeTypes) {
       const url = integration.resolveUrl({
@@ -122,7 +117,7 @@ export async function createRouter(
           content = (await symLinkUrlResponse.buffer()).toString('utf-8');
         }
 
-        cache.set(
+        await cache.set(
           entityRef,
           {
             name: fileType.name,
@@ -148,7 +143,7 @@ export async function createRouter(
       }
     }
     logger.info(`Readme not found for ${entityRef}`);
-    cache.set(
+    await cache.set(
       entityRef,
       {
         name: NOT_FOUND_PLACEHOLDER,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,15 +1577,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-readme-backend@workspace:plugins/readme-backend"
   dependencies:
-    "@backstage/backend-defaults": "npm:^0.15.1"
     "@backstage/backend-plugin-api": "npm:^1.6.2"
     "@backstage/backend-test-utils": "npm:^1.10.4"
-    "@backstage/catalog-client": "npm:^1.12.1"
     "@backstage/catalog-model": "npm:^1.7.6"
     "@backstage/cli": "npm:^0.35.1"
     "@backstage/config": "npm:^1.3.6"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/integration": "npm:^1.19.1"
+    "@backstage/plugin-catalog-node": "npm:^1.20.0"
     "@backstage/types": "npm:^1.2.2"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^2.0.12"
@@ -3432,7 +3431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.20.1":
+"@backstage/plugin-catalog-node@npm:^1.20.0, @backstage/plugin-catalog-node@npm:^1.20.1":
   version: 1.20.1
   resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,6 +1577,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@axis-backstage/plugin-readme-backend@workspace:plugins/readme-backend"
   dependencies:
+    "@backstage/backend-defaults": "npm:^0.15.1"
     "@backstage/backend-plugin-api": "npm:^1.6.2"
     "@backstage/backend-test-utils": "npm:^1.10.4"
     "@backstage/catalog-model": "npm:^1.7.6"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaced internally constructed `CatalogClient` with the injected `CatalogService` from `@backstage/plugin-catalog-node`. This removes the dependency on `@backstage/catalog-client` and `@backstage/backend-defaults`. 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have verified that my code follows the style already available in the repository
- [x] A changeset describing the change and affected packages. ([more info]