### PR TITLE
chore(app-next): example app updates

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -111,8 +111,8 @@ catalog:
         - allow: [User, Group]
 
     ## Uncomment these lines to add more example data
-    # - type: url
-    #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
 
     ## Uncomment these lines to add an example org
     # - type: url

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@axis-backstage/plugin-jira-dashboard": "workspace:^",
     "@axis-backstage/plugin-jira-dashboard-common": "workspace:^",
+    "@axis-backstage/plugin-readme": "workspace:^",
     "@backstage/app-defaults": "^1.7.7",
     "@backstage/catalog-model": "^1.8.0",
     "@backstage/cli": "^0.36.1",
@@ -35,6 +36,7 @@
     "@backstage/plugin-org": "^0.7.3",
     "@backstage/plugin-user-settings": "^0.9.2",
     "@backstage/theme": "^0.7.3",
+    "@backstage/ui": "0.14.3",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "history": "^5.0.0",

--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -6,6 +6,7 @@ import {
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
 import catalogImportPlugin from '@backstage/plugin-catalog-import/alpha';
 import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
+import readmePlugin from '@axis-backstage/plugin-readme/alpha';
 import { Navigate } from 'react-router';
 // if app.packages is not set in the app config, could manually add features like this
 // See documentation for details: https://backstage.io/docs/frontend-system/architecture/app#feature-discovery
@@ -19,11 +20,12 @@ const homePageExtension = PageBlueprint.make({
   },
 });
 
-export const app = createApp({
+const app = createApp({
   features: [
     catalogPlugin,
     catalogImportPlugin,
     userSettingsPlugin,
+    readmePlugin,
     createFrontendModule({
       pluginId: 'app',
       extensions: [homePageExtension],

--- a/packages/app-next/src/index.tsx
+++ b/packages/app-next/src/index.tsx
@@ -1,5 +1,6 @@
 import '@backstage/cli/asset-types';
 import ReactDOM from 'react-dom';
 import app from './App';
+import '@backstage/ui/css/styles.css';
 
 ReactDOM.render(app, document.getElementById('root'));

--- a/plugins/readme/README.md
+++ b/plugins/readme/README.md
@@ -66,7 +66,7 @@ const defaultEntityPage = (
 )
 ```
 
-To use `ReadmeCard` in a seperate page with full height:
+To use `ReadmeCard` in a separate page with full height:
 
 ```tsx
 import { ReadmeCard } from '@axis-backstage/plugin-readme';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/ui@npm:0.14.3":
+  version: 0.14.3
+  resolution: "@backstage/ui@npm:0.14.3"
+  dependencies:
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@remixicon/react": "npm:^4.6.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/1b1854db882f94d605ee270160cb95b72e8e8328b2fcc638d03590a27f3e4579da04272059168bbf152baf3bdf7b91e8d1ed55659bd80bde582fa5d8f20e7c72
+  languageName: node
+  linkType: hard
+
 "@backstage/ui@npm:^0.14.0, @backstage/ui@npm:^0.14.2":
   version: 0.14.2
   resolution: "@backstage/ui@npm:0.14.2"
@@ -15207,6 +15231,7 @@ __metadata:
   dependencies:
     "@axis-backstage/plugin-jira-dashboard": "workspace:^"
     "@axis-backstage/plugin-jira-dashboard-common": "workspace:^"
+    "@axis-backstage/plugin-readme": "workspace:^"
     "@backstage/app-defaults": "npm:^1.7.7"
     "@backstage/catalog-model": "npm:^1.8.0"
     "@backstage/cli": "npm:^0.36.1"
@@ -15227,6 +15252,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.9.2"
     "@backstage/test-utils": "npm:^1.7.17"
     "@backstage/theme": "npm:^0.7.3"
+    "@backstage/ui": "npm:0.14.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@playwright/test": "npm:^1.32.3"


### PR DESCRIPTION
## Summary

Updates the `app-next` example app (new frontend system demo) to include the `readme` plugin and a few housekeeping fixes.

### Changes

- **`packages/app-next`**: Add `@axis-backstage/plugin-readme` and `@backstage/ui` as dependencies; register `readmePlugin` in the app's features array; import `@backstage/ui/css/styles.css` in `index.tsx`
- **`app-config.yaml`**: Uncomment the example catalog URL so entities are available in the demo app out of the box
- **`plugins/readme/README.md`**: Fix typo "seperate" → "separate"