### PR TITLE
feat(readme): migrate ReadmeCard to EntityInfoCard

### DIFF
--- a/.changeset/readme-card-entity-info-card-migration.md
+++ b/.changeset/readme-card-entity-info-card-migration.md
@@ -1,0 +1,7 @@
+---
+'@axis-backstage/plugin-readme': minor
+---
+
+Migrated `ReadmeCard` from the legacy MUI `InfoCard` to `EntityInfoCard` from `@backstage/plugin-catalog-react`.
+
+The `variant` and `maxHeight` props have been removed from `ReadmeCardProps`. Users relying on these props should switch to `ReadmeCardLegacyProps`, which preserves the old behaviour and is accepted by `ReadmeCard` for backward compatibility. Both `variant` and `maxHeight` are deprecated and will be removed in a future release.

--- a/plugins/readme/report.api.md
+++ b/plugins/readme/report.api.md
@@ -19,12 +19,19 @@ export const isReadmeAvailable: (
 ) => Promise<boolean>;
 
 // @public
-export const ReadmeCard: (props: ReadmeCardProps) => JSX_2.Element | null;
+export const ReadmeCard: (
+  props: ReadmeCardProps | ReadmeCardLegacyProps,
+) => JSX_2.Element;
+
+// @public @deprecated
+export type ReadmeCardLegacyProps = {
+  variant?: InfoCardVariants;
+  maxHeight?: string | number;
+  hideIfNotFound?: boolean;
+};
 
 // @public
 export type ReadmeCardProps = {
-  variant?: InfoCardVariants;
-  maxHeight?: string | number;
   hideIfNotFound?: boolean;
 };
 

--- a/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
+++ b/plugins/readme/src/components/ReadmeCard/ReadmeCard.tsx
@@ -1,6 +1,7 @@
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import { EntityInfoCard } from '@backstage/plugin-catalog-react';
 import { InfoCard, InfoCardVariants } from '@backstage/core-components';
 import { ReadmeContent } from '../ReadmeContent';
 import { ReadmeDialog } from '../ReadmeDialog/ReadmeDialog';
@@ -13,12 +14,29 @@ import { ResponseError } from '@backstage/errors';
  * @public
  */
 export type ReadmeCardProps = {
+  hideIfNotFound?: boolean;
+};
+
+/**
+ * Props for the legacy MUI-based rendering of ReadmeCard.
+ * @deprecated Use {@link ReadmeCardProps} instead.
+ * @public
+ */
+export type ReadmeCardLegacyProps = {
+  /** @deprecated Use the new {@link ReadmeCardProps} instead. */
   variant?: InfoCardVariants;
+  /** @deprecated Use the new {@link ReadmeCardProps} instead. */
   maxHeight?: string | number;
   hideIfNotFound?: boolean;
 };
 
-export const ReadmeCard = (props: ReadmeCardProps) => {
+function isLegacyProps(
+  props: ReadmeCardProps | ReadmeCardLegacyProps,
+): props is ReadmeCardLegacyProps {
+  return 'variant' in props || 'maxHeight' in props;
+}
+
+function ReadmeCardLegacy(props: ReadmeCardLegacyProps) {
   const {
     variant = 'gridItem',
     maxHeight: propMaxHeight,
@@ -70,4 +88,53 @@ export const ReadmeCard = (props: ReadmeCardProps) => {
       />
     </>
   );
+}
+
+function ReadmeCardNew(props: ReadmeCardProps) {
+  const { hideIfNotFound } = props;
+  const [isFullViewOpen, setIsFullViewOpen] = useFullViewParam();
+  const readmeContent = useReadmeContent();
+
+  if (
+    hideIfNotFound &&
+    readmeContent.error instanceof ResponseError &&
+    readmeContent.error.statusCode === 404
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <EntityInfoCard
+        title="README"
+        headerActions={
+          <IconButton
+            onClick={() => setIsFullViewOpen(true)}
+            aria-label="Open full view"
+            title="Open full view"
+            size="large"
+          >
+            <FullscreenIcon />
+          </IconButton>
+        }
+      >
+        <div style={{ overflow: 'auto' }}>
+          <ReadmeContent {...readmeContent} />
+        </div>
+      </EntityInfoCard>
+
+      <ReadmeDialog
+        open={isFullViewOpen}
+        onClose={() => setIsFullViewOpen(false)}
+        {...readmeContent}
+      />
+    </>
+  );
+}
+
+export const ReadmeCard = (props: ReadmeCardProps | ReadmeCardLegacyProps) => {
+  if (isLegacyProps(props)) {
+    return <ReadmeCardLegacy {...props} />;
+  }
+  return <ReadmeCardNew {...props} />;
 };

--- a/plugins/readme/src/components/ReadmeCard/index.ts
+++ b/plugins/readme/src/components/ReadmeCard/index.ts
@@ -1,2 +1,2 @@
 export { ReadmeCard } from './ReadmeCard';
-export type { ReadmeCardProps } from './ReadmeCard';
+export type { ReadmeCardProps, ReadmeCardLegacyProps } from './ReadmeCard';

--- a/plugins/readme/src/index.ts
+++ b/plugins/readme/src/index.ts
@@ -5,5 +5,8 @@
  */
 
 export { readmePlugin, ReadmeCard } from './plugin';
-export type { ReadmeCardProps } from './components/ReadmeCard';
+export type {
+  ReadmeCardProps,
+  ReadmeCardLegacyProps,
+} from './components/ReadmeCard';
 export { isReadmeAvailable } from './api/ReadmeClient';


### PR DESCRIPTION
## Summary

Migrates `ReadmeCard` from the legacy MUI-based `InfoCard` (from `@backstage/core-components`) to `EntityInfoCard` (from `@backstage/plugin-catalog-react`), following the same pattern adopted upstream in the main Backstage repo for catalog card components.

## Changes

- **`ReadmeCard`** now uses `EntityInfoCard` (BUI-based) by default, with the fullscreen icon button placed in `headerActions`.
- A new **`ReadmeCardLegacyProps`** type is introduced for backward compatibility. It retains the deprecated `variant` and `maxHeight` props and continues to render using `InfoCard`. Users passing either prop will automatically get the legacy rendering path.
- **`ReadmeCardProps`** is simplified to only `hideIfNotFound`.
- `ReadmeCardLegacyProps` is exported from the package's public API.

## Migration

Users who relied on `variant` or `maxHeight` don't need to change anything — the legacy props are still accepted and will use the old `InfoCard` rendering. The new default uses `EntityInfoCard`.

## Checklist

- [x] Tests pass
- [x] API report updated
- [x] Changeset added (`minor` — `ReadmeCardProps` shape changed)