### PR TITLE
fix(jira-dashboard): Add name to ApiBlueprint in alpha export

### DIFF
--- a/.changeset/angry-brooms-push.md
+++ b/.changeset/angry-brooms-push.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard': patch
+---
+
+Fixed missing name on ApiBlueprint in alpha export, resolving crash when manually registering the plugin via createApp features array

--- a/plugins/jira-dashboard/src/alpha/apis.ts
+++ b/plugins/jira-dashboard/src/alpha/apis.ts
@@ -9,6 +9,7 @@ import { jiraDashboardApiRef, JiraDashboardClient } from '../api';
  * @alpha
  */
 export const jiraApi = ApiBlueprint.make({
+  name: 'api',
   params: defineParams =>
     defineParams({
       api: jiraDashboardApiRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Context

The /alpha export of @axis-backstage/plugin-jira-dashboard crashes at runtime when manually registered via createApp({ features: [...] }) due to a missing name parameter on the ApiBlueprint.make() call in src/alpha/apis.ts.

With feature discovery, the plugin context is already established so the namespace is available, but with manual registration, both namespace and name are undefined at resolution time, causing the crash:

Extension must declare an explicit namespace or name as it could not be resolved from context, kind=api namespace=undefined name=undefined

Adding name: 'api' resolves the issue for both manual registration and feature discovery..

### Issue ticket number and link

- Fixes #374 

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have verified that my code follows the style already available in the repository
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
