### PR TITLE
chore: add package repository metadata for Renovate changelogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Repo fix
+        run: yarn fix --check
+
       - name: Prettier
         run: yarn prettier:check
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "engines": {
     "node": "20 || 22 || 24"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins"
+  },
   "scripts": {
     "dev": "NODE_OPTIONS=--no-node-snapshot backstage-cli repo start",
     "dev-next": "npx backstage-cli repo start backend app-next",
@@ -22,7 +26,7 @@
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
     "test:e2e": "playwright test",
-    "fix": "backstage-cli repo fix",
+    "fix": "backstage-cli repo fix --publish",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "pack": "yarn workspaces foreach -A -v pack",

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.17",
   "private": true,
   "bundled": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "packages/app-next"
+  },
   "backstage": {
     "role": "frontend"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,6 +3,11 @@
   "version": "0.12.14",
   "private": true,
   "bundled": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "packages/app"
+  },
   "backstage": {
     "role": "frontend"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,6 +4,11 @@
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "packages/backend"
+  },
   "backstage": {
     "role": "backend"
   },

--- a/plugins/analytics-module-umami/package.json
+++ b/plugins/analytics-module-umami/package.json
@@ -10,6 +10,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/analytics-module-umami"
+  },
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "analytics-module-umami",

--- a/plugins/jira-dashboard-backend/package.json
+++ b/plugins/jira-dashboard-backend/package.json
@@ -10,6 +10,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/jira-dashboard-backend"
+  },
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "jira-dashboard",

--- a/plugins/jira-dashboard-common/package.json
+++ b/plugins/jira-dashboard-common/package.json
@@ -12,6 +12,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/jira-dashboard-common"
+  },
   "backstage": {
     "role": "common-library",
     "pluginId": "jira-dashboard",

--- a/plugins/jira-dashboard/package.json
+++ b/plugins/jira-dashboard/package.json
@@ -23,6 +23,11 @@
       ]
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/jira-dashboard"
+  },
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "jira-dashboard",

--- a/plugins/readme-backend/package.json
+++ b/plugins/readme-backend/package.json
@@ -10,6 +10,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/readme-backend"
+  },
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "readme",

--- a/plugins/readme/package.json
+++ b/plugins/readme/package.json
@@ -21,9 +21,12 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts",
     "directory": "_release/package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/readme"
   },
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/statuspage-backend/package.json
+++ b/plugins/statuspage-backend/package.json
@@ -10,6 +10,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/statuspage-backend"
+  },
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "statuspage",

--- a/plugins/statuspage-common/package.json
+++ b/plugins/statuspage-common/package.json
@@ -12,6 +12,11 @@
     "types": "dist/index.d.ts",
     "directory": "_release/package"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/statuspage-common"
+  },
   "backstage": {
     "role": "common-library",
     "pluginId": "statuspage",

--- a/plugins/statuspage/package.json
+++ b/plugins/statuspage/package.json
@@ -21,9 +21,12 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts",
     "directory": "_release/package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/statuspage"
   },
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/vacation-calendar/package.json
+++ b/plugins/vacation-calendar/package.json
@@ -21,9 +21,12 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts",
     "directory": "_release/package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxisCommunications/backstage-plugins",
+    "directory": "plugins/vacation-calendar"
   },
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Context

I noticed Renovate did not include the changelog for the plugins, presumably because of the lack of repository field. While this can be configured manually by end-users, adding the field is a best practice. This should also help users browsing npm packages find the source.

I can't test E2E as it touches packaging/publishing, but the packing step should take care of rewriting entrypoints properly.

### Issue ticket number and link

yet again no issue; please let me know if you wish this to stop :D 

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have verified that my code follows the style already available in the repository
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/AxisCommunications/backstage-plugins/blob/main/CONTRIBUTING.md#changesets))
  - Publishing chore, not sure we need it. 
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
