### PR TITLE
chore(readme-backend): remove inefficient regular expression

### DIFF
--- a/.changeset/honest-walls-joke.md
+++ b/.changeset/honest-walls-joke.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-readme-backend': patch
+---
+
+Remove inefficient regular expression when checking for symlinks.

--- a/plugins/readme-backend/src/lib.test.ts
+++ b/plugins/readme-backend/src/lib.test.ts
@@ -1,0 +1,11 @@
+import { isSymLink } from './lib';
+
+describe('isSymLink', () => {
+  it('accepts a non-empty single-line path without spaces', () => {
+    expect(isSymLink('../docs/README.md')).toBe(true);
+  });
+
+  it.each(['', 'README.md\n', 'README file'])('rejects %j', content => {
+    expect(isSymLink(content)).toBe(false);
+  });
+});

--- a/plugins/readme-backend/src/lib.ts
+++ b/plugins/readme-backend/src/lib.ts
@@ -1,11 +1,10 @@
-const DETECT_SYMLINKS_REGEX = '^(w+|.|/|-)+$';
-
 export const isSymLink = (content: string): boolean => {
-  const lines = content.split('\n');
-  if (lines.length > 1) return false;
-  const line = lines[0];
-  if (line.includes(' ')) return false;
-
-  const regex = RegExp(DETECT_SYMLINKS_REGEX);
-  return regex.test(content);
+  return (
+    content.length > 0 &&
+    !content.includes(' ') &&
+    !content.includes('\n') &&
+    !content.includes('\r') &&
+    !content.includes('\u2028') &&
+    !content.includes('\u2029')
+  );
 };


### PR DESCRIPTION
this expression can be very inefficient as reported by the github code scanner. Replaced with some simple string checks.

