### PR TITLE
Fix URL encoding of JQL query parameters

### DIFF
--- a/.changeset/fix-jira-jql-url-encoding.md
+++ b/.changeset/fix-jira-jql-url-encoding.md
@@ -1,0 +1,5 @@
+---
+'@axis-backstage/plugin-jira-dashboard-backend': patch
+---
+
+Fix URL encoding of JQL query parameters containing URL-reserved characters.

--- a/plugins/jira-dashboard-backend/src/api.test.ts
+++ b/plugins/jira-dashboard-backend/src/api.test.ts
@@ -239,6 +239,46 @@ describe('api', () => {
     ]);
   });
 
+  it('getIssuesByFilter encodes special characters in component names', async () => {
+    mswServer.use(
+      http.get('http://jira.com/rest/api/2/search', ({ request }) => {
+        const url = new URL(request.url);
+  
+        expect(request.url).toContain('A%26B');
+  
+        expect(url.searchParams.get('jql')).toBe(
+          "project in ('ppp') AND component in ('A&B') AND query",
+        );
+  
+        return HttpResponse.json({
+          issues: [
+            {
+              key: 'ppp-1',
+              self: 'http://jira.com/rest/api/2/issue/ppp-1',
+            },
+          ],
+        });
+      }),
+    );
+  
+    const projects = [
+      {
+        instance,
+        fullProjectKey: 'default/ppp',
+        projectKey: 'ppp',
+      },
+    ];
+  
+    const issues = await getIssuesByFilter(projects, ['A&B'], 'query');
+  
+    expect(issues).toEqual([
+      {
+        key: 'ppp-1',
+        self: 'http://jira.com/rest/api/2/issue/ppp-1',
+      },
+    ]);
+  });
+
   it('searchJira baseUrl', async () => {
     mswServer.use(
       http.post('http://jira.com/rest/api/2/search', async ({ request }) => {

--- a/plugins/jira-dashboard-backend/src/api.test.ts
+++ b/plugins/jira-dashboard-backend/src/api.test.ts
@@ -243,13 +243,13 @@ describe('api', () => {
     mswServer.use(
       http.get('http://jira.com/rest/api/2/search', ({ request }) => {
         const url = new URL(request.url);
-  
+
         expect(request.url).toContain('A%26B');
-  
+
         expect(url.searchParams.get('jql')).toBe(
           "project in ('ppp') AND component in ('A&B') AND query",
         );
-  
+
         return HttpResponse.json({
           issues: [
             {
@@ -260,7 +260,7 @@ describe('api', () => {
         });
       }),
     );
-  
+
     const projects = [
       {
         instance,
@@ -268,9 +268,9 @@ describe('api', () => {
         projectKey: 'ppp',
       },
     ];
-  
+
     const issues = await getIssuesByFilter(projects, ['A&B'], 'query');
-  
+
     expect(issues).toEqual([
       {
         key: 'ppp-1',

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -63,14 +63,14 @@ export const getQueryUrl = (instance: ConfigInstance, jql?: string): string => {
   if (instance.useApiV3) {
     const baseUrlWithEndpoint = `${baseUrl}search/jql`;
     if (jql) {
-      return `${baseUrlWithEndpoint}?jql=${jql}&fields=*all`;
+      return `${baseUrlWithEndpoint}?jql=${encodeURIComponent(jql)}&fields=*all`;
     }
     return baseUrlWithEndpoint;
   }
 
   const baseUrlWithEndpoint = `${baseUrl}search`;
   if (jql) {
-    return `${baseUrlWithEndpoint}?jql=${jql}`;
+    return `${baseUrlWithEndpoint}?jql=${encodeURIComponent(jql)}`;
   }
   return baseUrlWithEndpoint;
 };

--- a/plugins/jira-dashboard-backend/src/api.ts
+++ b/plugins/jira-dashboard-backend/src/api.ts
@@ -63,7 +63,9 @@ export const getQueryUrl = (instance: ConfigInstance, jql?: string): string => {
   if (instance.useApiV3) {
     const baseUrlWithEndpoint = `${baseUrl}search/jql`;
     if (jql) {
-      return `${baseUrlWithEndpoint}?jql=${encodeURIComponent(jql)}&fields=*all`;
+      return `${baseUrlWithEndpoint}?jql=${encodeURIComponent(
+        jql,
+      )}&fields=*all`;
     }
     return baseUrlWithEndpoint;
   }


### PR DESCRIPTION
## Description

Fixes Jira requests when JQL values contain URL-reserved characters such as `&`.

For example, a Jira component named `A&B` currently causes the JQL query parameter to be parsed incorrectly because the JQL is added to the request URL without URL encoding.

## Changes

* URL-encode the JQL query parameter for Jira API v2.
* URL-encode the JQL query parameter for Jira API v3.
* Add a regression test for component names containing `&`.

## Example

Before this change, a component such as:

```text
A&B
```

required a workaround:

```text
A%26B
```

After this change, the actual Jira component name can be used directly:

```text
A&B
```
