### PR TITLE
fix(changeset): ignore app/app-next/backend packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["app", "backend", "app-next"]
 }

--- a/.changeset/olive-planes-bump.md
+++ b/.changeset/olive-planes-bump.md
@@ -8,10 +8,7 @@
 '@axis-backstage/plugin-jira-dashboard': patch
 '@axis-backstage/plugin-readme-backend': patch
 '@axis-backstage/plugin-statuspage': patch
-'app-next': patch
-'backend': patch
 '@axis-backstage/plugin-readme': patch
-'app': patch
 ---
 
 Updated to Backstage 1.54.6


### PR DESCRIPTION
Current changeset action will not let us mix changesets with both ignored and not ignored packages.
